### PR TITLE
Encrypt & send "self share" to avoid rederiving in recovery (with optimized ECDH)

### DIFF
--- a/python/chilldkg_ref/chilldkg.py
+++ b/python/chilldkg_ref/chilldkg.py
@@ -16,7 +16,7 @@ from secp256k1proto.bip340 import schnorr_sign, schnorr_verify
 from secp256k1proto.keys import pubkey_gen_plain
 from secp256k1proto.util import int_from_bytes, bytes_from_int
 
-from .vss import VSS, VSSCommitment
+from .vss import VSSCommitment
 from . import encpedpop
 from .util import (
     BIP_TAG,
@@ -412,6 +412,7 @@ def participant_step1(
         # function. Thus, it is sufficient that the seed has a high entropy,
         # and so we can simply pass the hostseckey as seed.
         seed=hostseckey,
+        deckey=hostseckey,
         t=t,
         # This requires the joint security of Schnorr signatures and ECDH.
         enckeys=hostpubkeys,
@@ -650,9 +651,6 @@ def recover(
 
         # Decrypt share
         enc_context = encpedpop.serialize_enc_context(t, hostpubkeys)
-        simpl_seed = encpedpop.derive_simpl_seed(
-            hostseckey, pubnonces[idx], enc_context
-        )
         secshare = encpedpop.decrypt_sum(
             hostseckey,
             hostpubkeys[idx],
@@ -661,11 +659,6 @@ def recover(
             enc_context,
             idx,
         )
-
-        # Derive my_share
-        vss = VSS.generate(simpl_seed, t)
-        my_share = vss.secshare_for(idx)
-        secshare += my_share
 
         # This is just a sanity check. Our signature is valid, so we have done
         # this check already during the actual session.

--- a/python/tests.py
+++ b/python/tests.py
@@ -67,8 +67,11 @@ def simulate_encpedpop(seeds, t) -> List[Tuple[simplpedpop.DKGOutput, bytes]]:
 
     enckeys = [pret[1] for pret in enc_prets0]
     for i in range(n):
+        deckey = enc_prets0[i][0]
         random = random_bytes(32)
-        enc_prets1 += [encpedpop.participant_step1(seeds[i], t, enckeys, i, random)]
+        enc_prets1 += [
+            encpedpop.participant_step1(seeds[i], deckey, enckeys, t, i, random)
+        ]
 
     pmsgs = [pmsg for (_, pmsg) in enc_prets1]
     pstates = [pstate for (pstate, _) in enc_prets1]


### PR DESCRIPTION
Alternative to #43.

As opposed to what I claimed in #43, I've stuck to comparing the indices instead of the enckeys, because then don't need the array of all enckeys during decryption. Moreover, it seems a bit cleaner from a cryptographic point of view: We know for sure that our index belongs only to us, whereas our enckey could also belong to someone else in the sense that the attacker can claim to have the same enckey (at least in pure EncPedPop where we don't disallow duplicate pubkeys).

I doubt that comparing indices instead of enckeys makes a difference in terms of code complexity. The ugly thing (also for implementers) on master is the omission of the self_share in the array on the wire, which is hard to get right (easy off-by-one errors etc), and which this PR also gets rid off. 