### PR TITLE
text: visually stress usage requirements ("should"/"must")

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,9 +450,9 @@ should also read [Section "Internals of ChillDKG"](#internals-of-chilldkg).
 ChillDKG is designed for usage with the FROST Schnorr signature scheme,
 and its security depends on the specifics of FROST.
 We stress that ChillDKG is not a general-purpose DKG protocol,[^no-simulatable-dkg]
-and combining it with other threshold cryptographic schemes,
-e.g., threshold signature schemes other than FROST, or threshold decryption schemes
-requires careful further consideration, which is not endorsed or in the scope of this document.
+and **must not** be combined with other threshold cryptographic schemes,
+e.g., threshold signature schemes other than FROST, or threshold decryption schemes,
+without careful further consideration, which is not in the scope of this document.
 
 [^no-simulatable-dkg]: As a variant of Pedersen DKG, ChillDKG does not provide simulation-based security [GJKR07](https://doi.org/10.1007/s00145-006-0347-3). Roughly speaking, if ChillDKG is combined with some threshold cryptographic scheme, the security of the combination is not automatically implied by the security of the two components. Instead, the security of every combination must be analyzed separately. The security of the specific combination of SimplPedPop (as the core building block of ChillDKG) and FROST has been analyzed [CGRS23](https://eprint.iacr.org/2023/899).
 
@@ -490,7 +490,7 @@ they can request it from any other participants or the coordinator.
 Moreover, the recovery data contains secrets only in encrypted form and is self-authenticating
 so that it can, in principle, be stored with an untrusted third-party backup provider.
 
-Users should be aware that the session parameters (the threshold and the host public keys) and public parts of the DKG output (the threshold public key and the public shares) can be inferred from the recovery data, which may constitute a privacy issue.
+Users **should** be aware that the session parameters (the threshold and the host public keys) and public parts of the DKG output (the threshold public key and the public shares) can be inferred from the recovery data, which may constitute a privacy issue.
 To eliminate this issue, users can encrypt the recovery data using an encryption key derived from their host secret key before publishing the data.
 Recovery from encrypted data requires only the participant's host secret key, with no additional secrets needed.
 This BIP does not specify the encryption scheme.
@@ -516,7 +516,7 @@ The recovery data can, e.g., be attached to the first request to initiate a FROS
 
 An important implication of the above is that anyone who uses the threshold public key,
 and thereby relies on the participants' ability to participate in signing sessions,
-is responsible for ensuring that the participants have already deemed the DKG session successful,
+**must** ensure that the participants have already deemed the DKG session successful,
 or at least, that the recovery data will be available to convince any stuck participants of the success of the DKG session.
 
 For an example of what could go wrong,
@@ -524,13 +524,13 @@ assume that some participant deems the DKG session successful and uses the thres
 Even though everything looks fine from the perspective of this participant,
 it is entirely possible that this participant is the only one who has deemed the DKG session successful,
 and thus (besides the untrusted coordinator) the only one who knows the recovery data.
-If the recovery data is lost now because this participant's permanent storage crashes,
+If the recovery data is lost now because this participant's permanent storage fails,
 the other participants cannot be convinced to deem the DKG session successful
 (without the help of the untrusted coordinator)
 and so the funds will be lost.
 
 Thus, anyone who intends to use the threshold public key
-should first obtain explicit confirmations from all participants that they have deemed the DKG session successful,
+**should** first obtain explicit confirmations from all participants that they have deemed the DKG session successful,
 which will also imply that all participants have a redundant copy of the recovery data.
 One simple method of obtaining confirmation is to collect signed confirmation messages from all participants.
 
@@ -541,7 +541,7 @@ Alternatively, the user could check all `n` devices when generating a receiving 
 which constitutes the first use of the threshold public key.
 
 If a recovering party (see [Backup and Recovery](#backup-and-recovery)) cannot (re-)obtain confirmations,
-this simply means they should stop using the threshold public key going forward,
+this simply means they **should** stop using the threshold public key going forward,
 e.g., stop sending additional funds to addresses derived from it.
 (But, in contrast to the bad example laid out above,
 it will still be possible to spend the funds,
@@ -615,7 +615,7 @@ TODO Refer to the FROST signing BIP instead, once that one has a number.
 *Arguments*:
 
 - `hostseckey` - This participant's long-term secret key (32 bytes).
-  The key must be 32 bytes of cryptographically secure randomness
+  The key *must* be 32 bytes of cryptographically secure randomness
   with sufficient entropy to be unpredictable. All outputs of a
   successful participant in a session can be recovered from (a backup
   of) the key and per-session recovery data.
@@ -651,9 +651,9 @@ A `SessionParams` tuple holds the common parameters of a DKG session.
 - `hostpubkeys` - Ordered list of the host public keys of all participants.
 - `t` - The participation threshold `t`.
   This is the number of participants that will be required to sign.
-  It must hold that `1 <= t <= len(hostpubkeys)` and `t <= 2^32 - 1`.
+  It *must* hold that `1 <= t <= len(hostpubkeys)` and `t <= 2^32 - 1`.
 
-  Participants must ensure that they have obtained authentic host
+  Participants *must* ensure that they have obtained authentic host
   public keys of all the other participants in the session to make
   sure that they run the DKG and generate a threshold public key with
   the intended set of participants. This is analogous to traditional
@@ -666,8 +666,8 @@ A `SessionParams` tuple holds the common parameters of a DKG session.
   where the participants need to obtain authentic individual public
   keys of the other participants to generate an aggregated public key.
 
-  All participants and the coordinator in a session must be given an identical
-  `SessionParams` tuple. In particular, the host public keys must be in the
+  All participants and the coordinator in a session *must* be given an identical
+  `SessionParams` tuple. In particular, the host public keys *must* be in the
   same order. This will make sure that honest participants agree on the order
   as part of the session, which is useful if the order carries an implicit
   meaning in the application (e.g., if the first `t` participants are the
@@ -746,7 +746,7 @@ Perform a participant's first step of a ChillDKG session.
 *Returns*:
 
 - `ParticipantState1` - The participant's session state after this step, to
-  be passed as an argument to `participant_step2`. The state must not
+  be passed as an argument to `participant_step2`. The state *must not*
   be reused (i.e., it must be passed only to one
   `participant_step2` call).
 - `ParticipantMsg1` - The first message to be sent to the coordinator.
@@ -783,8 +783,8 @@ Perform a participant's second step of a ChillDKG session.
 *Returns*:
 
 - `ParticipantState2` - The participant's session state after this step, to
-  be passed as an argument to `participant_finalize`. The state must
-  not be reused (i.e., it must be passed only to one
+  be passed as an argument to `participant_finalize`. The state *must
+  not* be reused (i.e., it must be passed only to one
   `participant_finalize` call).
 - `ParticipantMsg2` - The second message to be sent to the coordinator.
 
@@ -821,8 +821,8 @@ function.
 
 *Warning:*
 Changing perspectives, this implies that even when obtaining a
-`SessionNotFinalizedError`, you MUST NOT conclude that the DKG session has
-failed, and as a consequence, you MUST NOT erase the hostseckey. The underlying
+`SessionNotFinalizedError`, you *must not* conclude that the DKG session has
+failed, and as a consequence, you *must not* erase the hostseckey. The underlying
 reason is that some other participant may deem the DKG session successful
 and use the resulting threshold public key (e.g., by sending funds to it).
 That other participant can, at any point in the future, wish to convince us

--- a/README.md
+++ b/README.md
@@ -615,7 +615,7 @@ TODO Refer to the FROST signing BIP instead, once that one has a number.
 *Arguments*:
 
 - `hostseckey` - This participant's long-term secret key (32 bytes).
-  The key *must* be 32 bytes of cryptographically secure randomness
+  The key **must** be 32 bytes of cryptographically secure randomness
   with sufficient entropy to be unpredictable. All outputs of a
   successful participant in a session can be recovered from (a backup
   of) the key and per-session recovery data.
@@ -651,9 +651,9 @@ A `SessionParams` tuple holds the common parameters of a DKG session.
 - `hostpubkeys` - Ordered list of the host public keys of all participants.
 - `t` - The participation threshold `t`.
   This is the number of participants that will be required to sign.
-  It *must* hold that `1 <= t <= len(hostpubkeys)` and `t <= 2^32 - 1`.
+  It must hold that `1 <= t <= len(hostpubkeys)` and `t <= 2^32 - 1`.
 
-  Participants *must* ensure that they have obtained authentic host
+  Participants **must** ensure that they have obtained authentic host
   public keys of all the other participants in the session to make
   sure that they run the DKG and generate a threshold public key with
   the intended set of participants. This is analogous to traditional
@@ -666,16 +666,15 @@ A `SessionParams` tuple holds the common parameters of a DKG session.
   where the participants need to obtain authentic individual public
   keys of the other participants to generate an aggregated public key.
 
-  All participants and the coordinator in a session *must* be given an identical
-  `SessionParams` tuple. In particular, the host public keys *must* be in the
-  same order. This will make sure that honest participants agree on the order
-  as part of the session, which is useful if the order carries an implicit
-  meaning in the application (e.g., if the first `t` participants are the
-  primary participants for signing and the others are fallback participants).
-  If there is no canonical order of the participants in the application, the
-  caller can sort the list of host public keys with the [KeySort algorithm
-  specified in
-  BIP 327](https://github.com/bitcoin/bips/blob/master/bip-0327.mediawiki#key-sorting)
+  A DKG session will fail if the participants and the coordinator in a session
+  don't have the `hostpubkeys` in the same order. This will make sure that
+  honest participants agree on the order as part of the session, which is
+  useful if the order carries an implicit meaning in the application (e.g., if
+  the first `t` participants are the primary participants for signing and the
+  others are fallback participants). If there is no canonical order of the
+  participants in the application, the caller can sort the list of host public
+  keys with the [KeySort algorithm specified in BIP
+  327](https://github.com/bitcoin/bips/blob/master/bip-0327.mediawiki#key-sorting)
   to abstract away from the order.
 
 #### params\_id
@@ -746,7 +745,7 @@ Perform a participant's first step of a ChillDKG session.
 *Returns*:
 
 - `ParticipantState1` - The participant's session state after this step, to
-  be passed as an argument to `participant_step2`. The state *must not*
+  be passed as an argument to `participant_step2`. The state **must not**
   be reused (i.e., it must be passed only to one
   `participant_step2` call).
 - `ParticipantMsg1` - The first message to be sent to the coordinator.
@@ -783,8 +782,8 @@ Perform a participant's second step of a ChillDKG session.
 *Returns*:
 
 - `ParticipantState2` - The participant's session state after this step, to
-  be passed as an argument to `participant_finalize`. The state *must
-  not* be reused (i.e., it must be passed only to one
+  be passed as an argument to `participant_finalize`. The state **must
+  not** be reused (i.e., it must be passed only to one
   `participant_finalize` call).
 - `ParticipantMsg2` - The second message to be sent to the coordinator.
 
@@ -821,8 +820,8 @@ function.
 
 *Warning:*
 Changing perspectives, this implies that even when obtaining a
-`SessionNotFinalizedError`, you *must not* conclude that the DKG session has
-failed, and as a consequence, you *must not* erase the hostseckey. The underlying
+`SessionNotFinalizedError`, you **must not** conclude that the DKG session has
+failed, and as a consequence, you **must not** erase the hostseckey. The underlying
 reason is that some other participant may deem the DKG session successful
 and use the resulting threshold public key (e.g., by sending funds to it).
 That other participant can, at any point in the future, wish to convince us

--- a/python/chilldkg_ref/chilldkg.py
+++ b/python/chilldkg_ref/chilldkg.py
@@ -186,7 +186,7 @@ class SessionParams(NamedTuple):
         hostpubkeys: Ordered list of the host public keys of all participants.
         t: The participation threshold `t`.
             This is the number of participants that will be required to sign.
-            It **must** hold that `1 <= t <= len(hostpubkeys)` and `t <= 2^32 - 1`.
+            It must hold that `1 <= t <= len(hostpubkeys)` and `t <= 2^32 - 1`.
 
     Participants **must** ensure that they have obtained authentic host
     public keys of all the other participants in the session to make
@@ -201,16 +201,15 @@ class SessionParams(NamedTuple):
     where the participants need to obtain authentic individual public
     keys of the other participants to generate an aggregated public key.
 
-    All participants and the coordinator in a session **must** be given an identical
-    `SessionParams` tuple. In particular, the host public keys **must** be in the
-    same order. This will make sure that honest participants agree on the order
-    as part of the session, which is useful if the order carries an implicit
-    meaning in the application (e.g., if the first `t` participants are the
-    primary participants for signing and the others are fallback participants).
-    If there is no canonical order of the participants in the application, the
-    caller can sort the list of host public keys with the [KeySort algorithm
-    specified in
-    BIP 327](https://github.com/bitcoin/bips/blob/master/bip-0327.mediawiki#key-sorting)
+    A DKG session will fail if the participants and the coordinator in a session
+    don't have the `hostpubkeys` in the same order. This will make sure that
+    honest participants agree on the order as part of the session, which is
+    useful if the order carries an implicit meaning in the application (e.g., if
+    the first `t` participants are the primary participants for signing and the
+    others are fallback participants). If there is no canonical order of the
+    participants in the application, the caller can sort the list of host public
+    keys with the [KeySort algorithm specified in BIP
+    327](https://github.com/bitcoin/bips/blob/master/bip-0327.mediawiki#key-sorting)
     to abstract away from the order.
     """
 

--- a/python/chilldkg_ref/chilldkg.py
+++ b/python/chilldkg_ref/chilldkg.py
@@ -147,7 +147,7 @@ def hostpubkey_gen(hostseckey: bytes) -> bytes:
 
     Arguments:
         hostseckey: This participant's long-term secret key (32 bytes).
-            The key must be 32 bytes of cryptographically secure randomness
+            The key **must** be 32 bytes of cryptographically secure randomness
             with sufficient entropy to be unpredictable. All outputs of a
             successful participant in a session can be recovered from (a backup
             of) the key and per-session recovery data.
@@ -186,9 +186,9 @@ class SessionParams(NamedTuple):
         hostpubkeys: Ordered list of the host public keys of all participants.
         t: The participation threshold `t`.
             This is the number of participants that will be required to sign.
-            It must hold that `1 <= t <= len(hostpubkeys)` and `t <= 2^32 - 1`.
+            It **must** hold that `1 <= t <= len(hostpubkeys)` and `t <= 2^32 - 1`.
 
-    Participants must ensure that they have obtained authentic host
+    Participants **must** ensure that they have obtained authentic host
     public keys of all the other participants in the session to make
     sure that they run the DKG and generate a threshold public key with
     the intended set of participants. This is analogous to traditional
@@ -201,8 +201,8 @@ class SessionParams(NamedTuple):
     where the participants need to obtain authentic individual public
     keys of the other participants to generate an aggregated public key.
 
-    All participants and the coordinator in a session must be given an identical
-    `SessionParams` tuple. In particular, the host public keys must be in the
+    All participants and the coordinator in a session **must** be given an identical
+    `SessionParams` tuple. In particular, the host public keys **must** be in the
     same order. This will make sure that honest participants agree on the order
     as part of the session, which is useful if the order carries an implicit
     meaning in the application (e.g., if the first `t` participants are the
@@ -403,7 +403,7 @@ def participant_step1(
 
     Returns:
         ParticipantState1: The participant's session state after this step, to
-            be passed as an argument to `participant_step2`. The state must not
+            be passed as an argument to `participant_step2`. The state **must not**
             be reused (i.e., it must be passed only to one
             `participant_step2` call).
         ParticipantMsg1: The first message to be sent to the coordinator.
@@ -456,8 +456,8 @@ def participant_step2(
 
     Returns:
         ParticipantState2: The participant's session state after this step, to
-            be passed as an argument to `participant_finalize`. The state must
-            not be reused (i.e., it must be passed only to one
+            be passed as an argument to `participant_finalize`. The state **must
+            not** be reused (i.e., it must be passed only to one
             `participant_finalize` call).
         ParticipantMsg2: The second message to be sent to the coordinator.
 
@@ -516,8 +516,8 @@ def participant_finalize(
 
     **Warning:**
     Changing perspectives, this implies that even when obtaining a
-    `SessionNotFinalizedError`, you MUST NOT conclude that the DKG session has
-    failed, and as a consequence, you MUST NOT erase the hostseckey. The underlying
+    `SessionNotFinalizedError`, you **must not** conclude that the DKG session has
+    failed, and as a consequence, you **must not** erase the hostseckey. The underlying
     reason is that some other participant may deem the DKG session successful
     and use the resulting threshold public key (e.g., by sending funds to it).
     That other participant can, at any point in the future, wish to convince us

--- a/update-pydoc.sh
+++ b/update-pydoc.sh
@@ -12,8 +12,10 @@ for i in "chilldkg,Tuples" "util,Expection"; do
 pydoc-markdown -I python/chilldkg_ref -m "$module" "{renderer: {type: markdown, insert_header_anchors: false, render_module_header: no, format_code: no, header_level_by_type: {\"Function\": 4, \"Class\": 4, \"Method\": 5}, descriptive_class_title: \"$ ${class_title}\" }}" |
     # Remove header
     sed -z 's/[^#]*#/#/' |
-    # Replace bold (**) by italics (*)
-    sed -z 's/\*\*/*/g' >> pydoc.md
+    # Replace bold (**) by italics (*), but not for **must**, **must not**,
+    # **should**, or **should not**.
+    python3 -c "import re, sys; sys.stdout.write(re.sub(r'\*\*(?!must\*\*|should\*\*|must not\*\*|should not\*\*)(.*?)\*\*', r'*\1*', sys.stdin.read()))" >> pydoc.md
+
 done
 
 # Remove trailing newline


### PR DESCRIPTION
Fixes #56.

This should also make it easier to grep important usage guidelines by grepping for bold (or italic, see below) text.

Asterisks in bold text pydoc strings are stripped such that they only appear italic. This is explicitly implemented in `update-pydoc.sh`. Is there a particular reason for this @real-or-random ?

I also removed the capitalization from two occurences of "MUST NOT" in a pydoc string for consistency. Because these strings are now only italic, they're actually less visually highlighted.