### PR TITLE
encpedpop: Decide on libsecp256k1 ECDH variant

### DIFF
--- a/python/chilldkg_ref/encpedpop.py
+++ b/python/chilldkg_ref/encpedpop.py
@@ -22,7 +22,6 @@ from .util import (
 def ecdh(
     seckey: bytes, my_pubkey: bytes, their_pubkey: bytes, context: bytes, sending: bool
 ) -> Scalar:
-    # TODO Decide on exact ecdh variant to use
     data = ecdh_libsecp256k1(seckey, their_pubkey)
     if sending:
         data += my_pubkey + their_pubkey

--- a/python/secp256k1proto/ecdh.py
+++ b/python/secp256k1proto/ecdh.py
@@ -3,7 +3,7 @@ import hashlib
 from .secp256k1 import GE, Scalar
 
 
-def ecdh_uncompressed_in_raw_out(seckey: bytes, pubkey: bytes) -> GE:
+def ecdh_compressed_in_raw_out(seckey: bytes, pubkey: bytes) -> GE:
     """TODO"""
     shared_secret = Scalar.from_bytes(seckey) * GE.from_bytes_compressed(pubkey)
     assert not shared_secret.infinity  # prime-order group
@@ -12,5 +12,5 @@ def ecdh_uncompressed_in_raw_out(seckey: bytes, pubkey: bytes) -> GE:
 
 def ecdh_libsecp256k1(seckey: bytes, pubkey: bytes) -> bytes:
     """TODO"""
-    shared_secret = ecdh_uncompressed_in_raw_out(seckey, pubkey)
+    shared_secret = ecdh_compressed_in_raw_out(seckey, pubkey)
     return hashlib.sha256(shared_secret.to_bytes_compressed()).digest()


### PR DESCRIPTION
What we have is good. We could save one hash application by putting everything into a single hash, but compatibility with the established libsecp256k1 interface is a good idea.

This also fixes a typo in a function name in secp256k1ref. 