### PR TITLE
chilldkg: fix enc_secshare deserialization

### DIFF
--- a/python/chilldkg_ref/chilldkg.py
+++ b/python/chilldkg_ref/chilldkg.py
@@ -14,7 +14,7 @@ from typing import Any, Tuple, List, NamedTuple, NewType, Optional, NoReturn, Di
 from secp256k1proto.secp256k1 import Scalar, GE
 from secp256k1proto.bip340 import schnorr_sign, schnorr_verify
 from secp256k1proto.keys import pubkey_gen_plain
-from secp256k1proto.util import int_from_bytes, bytes_from_int
+from secp256k1proto.util import bytes_from_int
 
 from .vss import VSSCommitment
 from . import encpedpop
@@ -392,7 +392,7 @@ def deserialize_recovery_data(
     if len(rest) < 32 * n:
         raise ValueError
     enc_secshares, rest = (
-        [Scalar(int_from_bytes(rest[i : i + 32])) for i in range(0, 32 * n, 32)],
+        [Scalar.from_bytes(rest[i : i + 32]) for i in range(0, 32 * n, 32)],
         rest[32 * n :],
     )
 


### PR DESCRIPTION
While deserializing recovery data, for `enc_secshare`, we should use `Scalar.from_bytes(...)` instead of `Scalar(int_from_bytes(...))`. The latter does not raise a `ValueError` for overflowed values; it silently applies modulo to produce a valid `Scalar` element!

`Scalar(int_from_bytes(...))` is also used for generating pads (`self_pad` and `ecdh`). I think this is acceptable since we’re generating random numbers, not deserializing data.