### PR TITLE
simplpedpop: remove unused `aux_rand` parameter from `pop_prove`

### DIFF
--- a/python/chilldkg_ref/simplpedpop.py
+++ b/python/chilldkg_ref/simplpedpop.py
@@ -35,7 +35,7 @@ def pop_msg(idx: int) -> bytes:
     return idx.to_bytes(4, byteorder="big")
 
 
-def pop_prove(seckey: bytes, idx: int, aux_rand: bytes = 32 * b"\x00") -> Pop:
+def pop_prove(seckey: bytes, idx: int) -> Pop:
     sig = schnorr_sign(
         pop_msg(idx), seckey, aux_rand=random_bytes(32), tag_prefix=POP_MSG_TAG
     )


### PR DESCRIPTION
The `aux_rand` parameter in `pop_prove` is currently not used, neither within the function nor at the call-site in `participant_step1` below, so it seems reasonable to remove it. Alternatively, if the intention was really to keep it, it should be passed to `schnorr_sign` and the default value could be set to `random_bytes(32)` instead of all-zeros.