### PR TITLE
secp256k1proto: split `APrimeFE.from_bytes` into checked and wrapping variants

### DIFF
--- a/python/chilldkg_ref/chilldkg.py
+++ b/python/chilldkg_ref/chilldkg.py
@@ -392,7 +392,7 @@ def deserialize_recovery_data(
     if len(rest) < 32 * n:
         raise ValueError
     enc_secshares, rest = (
-        [Scalar.from_bytes(rest[i : i + 32]) for i in range(0, 32 * n, 32)],
+        [Scalar.from_bytes_checked(rest[i : i + 32]) for i in range(0, 32 * n, 32)],
         rest[32 * n :],
     )
 

--- a/python/chilldkg_ref/encpedpop.py
+++ b/python/chilldkg_ref/encpedpop.py
@@ -3,7 +3,6 @@ from typing import Tuple, List, NamedTuple, NoReturn
 from secp256k1proto.secp256k1 import Scalar, GE
 from secp256k1proto.ecdh import ecdh_libsecp256k1
 from secp256k1proto.keys import pubkey_gen_plain
-from secp256k1proto.util import int_from_bytes
 
 from . import simplpedpop
 from .util import (
@@ -29,15 +28,13 @@ def ecdh(
         data += their_pubkey + my_pubkey
     assert len(data) == 32 + 2 * 33
     data += context
-    return Scalar(int_from_bytes(tagged_hash_bip_dkg("encpedpop ecdh", data)))
+    return Scalar.from_bytes_wrapping(tagged_hash_bip_dkg("encpedpop ecdh", data))
 
 
 def self_pad(symkey: bytes, nonce: bytes, context: bytes) -> Scalar:
     # Pad for symmetric encryption to ourselves
-    return Scalar(
-        int_from_bytes(
-            tagged_hash_bip_dkg("encaps_multi self_pad", symkey + nonce + context)
-        )
+    return Scalar.from_bytes_wrapping(
+        tagged_hash_bip_dkg("encaps_multi self_pad", symkey + nonce + context)
     )
 
 

--- a/python/chilldkg_ref/vss.py
+++ b/python/chilldkg_ref/vss.py
@@ -95,7 +95,7 @@ class VSSCommitment:
         # The function returns the updated VSS commitment and the tweak `t` which
         # must be added to all secret shares of the commitment.
         pk = self.commitment_to_secret()
-        secshare_tweak = Scalar.from_bytes(
+        secshare_tweak = Scalar.from_bytes_checked(
             tagged_hash("TapTweak", pk.to_bytes_compressed())
         )
         pubshare_tweak = secshare_tweak * G
@@ -112,7 +112,7 @@ class VSS:
     @staticmethod
     def generate(seed: bytes, t: int) -> VSS:
         coeffs = [
-            Scalar.from_bytes(
+            Scalar.from_bytes_checked(
                 tagged_hash_bip_dkg("vss coeffs", seed + i.to_bytes(4, byteorder="big"))
             )
             for i in range(t)

--- a/python/secp256k1proto/ecdh.py
+++ b/python/secp256k1proto/ecdh.py
@@ -5,7 +5,7 @@ from .secp256k1 import GE, Scalar
 
 def ecdh_compressed_in_raw_out(seckey: bytes, pubkey: bytes) -> GE:
     """TODO"""
-    shared_secret = Scalar.from_bytes(seckey) * GE.from_bytes_compressed(pubkey)
+    shared_secret = Scalar.from_bytes_checked(seckey) * GE.from_bytes_compressed(pubkey)
     assert not shared_secret.infinity  # prime-order group
     return shared_secret
 

--- a/python/secp256k1proto/secp256k1.py
+++ b/python/secp256k1proto/secp256k1.py
@@ -142,6 +142,12 @@ class APrimeFE:
             raise ValueError
         return cls(v)
 
+    @classmethod
+    def from_bytes_wrapping(cls, b):
+        """Convert a 32-byte array to a field element (BE byte order, reduced modulo SIZE)."""
+        v = int.from_bytes(b, 'big')
+        return cls(v % cls.SIZE)
+
     def __str__(self):
         """Convert this field element to a 64 character hex string."""
         return f"{int(self):064x}"

--- a/python/secp256k1proto/secp256k1.py
+++ b/python/secp256k1proto/secp256k1.py
@@ -135,7 +135,7 @@ class APrimeFE:
         return int(self).to_bytes(32, 'big')
 
     @classmethod
-    def from_bytes(cls, b):
+    def from_bytes_checked(cls, b):
         """Convert a 32-byte array to a field element (BE byte order, no overflow allowed)."""
         v = int.from_bytes(b, 'big')
         if v >= cls.SIZE:
@@ -345,7 +345,7 @@ class GE:
         assert len(b) == 33
         if b[0] != 2 and b[0] != 3:
             raise ValueError
-        x = FE.from_bytes(b[1:])
+        x = FE.from_bytes_checked(b[1:])
         r = GE.lift_x(x)
         if b[0] == 3:
             r = -r
@@ -357,8 +357,8 @@ class GE:
         assert len(b) == 65
         if b[0] != 4:
             raise ValueError
-        x = FE.from_bytes(b[1:33])
-        y = FE.from_bytes(b[33:])
+        x = FE.from_bytes_checked(b[1:33])
+        y = FE.from_bytes_checked(b[33:])
         if y**2 != x**3 + 7:
             raise ValueError
         return GE(x, y)
@@ -376,7 +376,7 @@ class GE:
     def from_bytes_xonly(b):
         """Convert a point given in xonly encoding to a group element."""
         assert len(b) == 32
-        x = FE.from_bytes(b)
+        x = FE.from_bytes_checked(b)
         r = GE.lift_x(x)
         return r
 

--- a/python/tests.py
+++ b/python/tests.py
@@ -310,7 +310,7 @@ def test_correctness_dkg_output(t, n, dkg_outputs: List[simplpedpop.DKGOutput]):
 
     # Check that each secshare matches the corresponding pubshare
     secshares_scalar = [
-        None if secshare is None else Scalar.from_bytes(secshare)
+        None if secshare is None else Scalar.from_bytes_checked(secshare)
         for secshare in secshares
     ]
     for i in range(1, n + 1):


### PR DESCRIPTION
Note that the issue title refers to a `from_int` method, but since the check-or-wraparound discussion mostly concerns the initialization of scalars/fes from byte-strings (e.g. pseudo-random data from tagged hash results), the split-up is applied on the `.from_bytes` method. As suggested in #77, the BIP-340 implementation is not adapted and still applies the wrapping manually (`% GE.ORDER`), in order to keep it close to the reference implementation.

Resolves #77. 