### PR TITLE
secp256k1proto: deserialize x-only-pk with `from_bytes_xonly` (schnorr_verify)

### DIFF
--- a/python/secp256k1proto/bip340.py
+++ b/python/secp256k1proto/bip340.py
@@ -56,7 +56,7 @@ def schnorr_verify(
     if len(sig) != 64:
         raise ValueError("The signature must be a 64-byte array.")
     try:
-        P = GE.lift_x(int_from_bytes(pubkey))
+        P = GE.from_bytes_xonly(pubkey)
     except ValueError:
         return False
     r = int_from_bytes(sig[0:32])


### PR DESCRIPTION
If the passed x-only-pubkey overflows (x >= p), this method fails immediately rather than silently wrapping around and then likely failing later (either because x % p is not on the curve or because the actual signature verification fails [1]). For the user of `schnorr_verify` this shouldn't make any difference, as `False` is returned with both variants, so this is probably more of a cosmetic change.

[1] `b'\xff'*32` is an example x-only-pubkey for the latter case