### PR TITLE
Add .gitignore to avoid tracking python-generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Python-generated files
+__pycache__/
+*.py[oc]
+build/
+dist/
+wheels/
+*.egg-info
+
+# Virtual environments
+.venv


### PR DESCRIPTION
Avoids tracking pre-compiled python files that are created in the course of running the tests or examples for the first time, e.g. on master:

```
$ ./python/tests.sh && git status
On branch master
Your branch is up to date with 'origin/master'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)
        python/__pycache__/
        python/chilldkg_ref/__pycache__/
        python/secp256k1lab/__pycache__/

nothing added to commit but untracked files present (use "git add" to track)
```