### PR TITLE
Serialize Messages as Bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -868,7 +868,7 @@ Holds the outputs of a DKG session.
 #### participant\_step1
 
 ```python
-def participant_step1(hostseckey: bytes, params: SessionParams, random: bytes) -> Tuple[ParticipantState1, ParticipantMsg1]
+def participant_step1(hostseckey: bytes, params: SessionParams, random: bytes) -> Tuple[ParticipantState1, bytes]
 ```
 
 Perform a participant's first step of a ChillDKG session.
@@ -886,7 +886,7 @@ Perform a participant's first step of a ChillDKG session.
   be passed as an argument to `participant_step2`. The state **must
   not** be reused (i.e., it must be passed only to one
   `participant_step2` call).
-- `ParticipantMsg1` - The first message to be sent to the coordinator.
+- `bytes` - The first message to be sent to the coordinator.
 
 
 *Raises*:
@@ -901,7 +901,7 @@ Perform a participant's first step of a ChillDKG session.
 #### participant\_step2
 
 ```python
-def participant_step2(hostseckey: bytes, state1: ParticipantState1, cmsg1: CoordinatorMsg1) -> Tuple[ParticipantState2, ParticipantMsg2]
+def participant_step2(hostseckey: bytes, state1: ParticipantState1, cmsg1: bytes) -> Tuple[ParticipantState2, bytes]
 ```
 
 Perform a participant's second step of a ChillDKG session.
@@ -932,7 +932,7 @@ data, from which this participant can recover the DKG output using the
   be passed as an argument to `participant_finalize`. The state **must
   not** be reused (i.e., it must be passed only to one
   `participant_finalize` call).
-- `ParticipantMsg2` - The second message to be sent to the coordinator.
+- `bytes` - The second message to be sent to the coordinator.
 
 
 *Raises*:
@@ -950,7 +950,7 @@ data, from which this participant can recover the DKG output using the
 #### participant\_finalize
 
 ```python
-def participant_finalize(state2: ParticipantState2, cmsg2: CoordinatorMsg2) -> Tuple[DKGOutput, RecoveryData]
+def participant_finalize(state2: ParticipantState2, cmsg2: bytes) -> Tuple[DKGOutput, RecoveryData]
 ```
 
 Perform a participant's final step of a ChillDKG session.
@@ -977,6 +977,7 @@ recovery data to this participant.
 *Arguments*:
 
 - `state2` - The participant's state as output by `participant_step2`.
+- `cmsg2` - The second message received from the coordinator.
 
 
 *Returns*:
@@ -997,7 +998,7 @@ recovery data to this participant.
 #### participant\_investigate
 
 ```python
-def participant_investigate(error: UnknownFaultyParticipantOrCoordinatorError, cinv: CoordinatorInvestigationMsg) -> NoReturn
+def participant_investigate(error: UnknownFaultyParticipantOrCoordinatorError, cinv: bytes) -> NoReturn
 ```
 
 Investigate who is to blame for a failed ChillDKG session.
@@ -1028,7 +1029,7 @@ exceptions.
 #### coordinator\_step1
 
 ```python
-def coordinator_step1(pmsgs1: List[ParticipantMsg1], params: SessionParams) -> Tuple[CoordinatorState, CoordinatorMsg1]
+def coordinator_step1(pmsgs1: List[bytes], params: SessionParams) -> Tuple[CoordinatorState, bytes]
 ```
 
 Perform the coordinator's first step of a ChillDKG session.
@@ -1045,7 +1046,7 @@ Perform the coordinator's first step of a ChillDKG session.
   passed as an argument to `coordinator_finalize`. The state is not
   supposed to be reused (i.e., it should be passed only to one
   `coordinator_finalize` call).
-- `CoordinatorMsg1` - The first message to be sent to all participants.
+- `bytes` - The first message to be sent to all participants.
 
 
 *Raises*:
@@ -1058,7 +1059,7 @@ Perform the coordinator's first step of a ChillDKG session.
 #### coordinator\_finalize
 
 ```python
-def coordinator_finalize(state: CoordinatorState, pmsgs2: List[ParticipantMsg2]) -> Tuple[CoordinatorMsg2, DKGOutput, RecoveryData]
+def coordinator_finalize(state: CoordinatorState, pmsgs2: List[bytes]) -> Tuple[bytes, DKGOutput, RecoveryData]
 ```
 
 Perform the coordinator's final step of a ChillDKG session.
@@ -1089,7 +1090,7 @@ other participants via a communication channel beside the coordinator.
 
 *Returns*:
 
-- `CoordinatorMsg2` - The second message to be sent to all participants.
+- `bytes` - The second message to be sent to all participants.
 - `DKGOutput` - The DKG output. Since the coordinator does not have a secret
   share, the DKG output will have the `secshare` field set to `None`.
 - `bytes` - The serialized recovery data.
@@ -1104,7 +1105,7 @@ other participants via a communication channel beside the coordinator.
 #### coordinator\_investigate
 
 ```python
-def coordinator_investigate(pmsgs: List[ParticipantMsg1]) -> List[CoordinatorInvestigationMsg]
+def coordinator_investigate(pmsgs: List[bytes]) -> List[bytes]
 ```
 
 Generate investigation messages for a ChillDKG session.
@@ -1118,13 +1119,14 @@ information.
 
 *Arguments*:
 
-- `pmsgs` - List of first messages received from the participants.
+- `pmsgs` - List of serialized first messages received from the participants.
+- `params` - Common session parameters.
 
 
 *Returns*:
 
-- `List[CoordinatorInvestigationMsg]` - A list of investigation messages, each
-  intended for a single participant.
+- `List[bytes]` - A list of investigation messages, each intended for a single
+  participant.
 
 #### recover
 

--- a/python/chilldkg_ref/simplpedpop.py
+++ b/python/chilldkg_ref/simplpedpop.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from secrets import token_bytes as random_bytes
 from typing import List, NamedTuple, NewType, Tuple, Optional, NoReturn
 
@@ -55,6 +57,35 @@ class ParticipantMsg(NamedTuple):
     com: VSSCommitment
     pop: Pop
 
+    def to_bytes(self) -> bytes:
+        return self.com.to_bytes() + self.pop
+
+    @staticmethod
+    def from_bytes(b: bytes) -> ParticipantMsg:
+        rest = b
+
+        # Read Pop (64 bytes)
+        if len(rest) < 64:
+            raise ValueError
+        pop, rest = Pop(rest[-64:]), rest[:-64]
+
+        # Compute t
+        t, remainder = divmod(len(rest), 33)
+        if remainder != 0:
+            raise ValueError
+
+        # Read com (33*t bytes)
+        if len(rest) < 33 * t:
+            raise ValueError
+        com, rest = (
+            VSSCommitment.from_bytes_and_t(rest[: 33 * t], t),
+            rest[33 * t :],
+        )
+
+        if len(rest) != 0:
+            raise ValueError
+        return ParticipantMsg(com, pop)
+
 
 class CoordinatorMsg(NamedTuple):
     coms_to_secrets: List[GE]
@@ -69,9 +100,81 @@ class CoordinatorMsg(NamedTuple):
             ]
         ) + b"".join(self.pops)
 
+    @staticmethod
+    def from_bytes_and_n(b: bytes, n: int) -> CoordinatorMsg:
+        rest = b
+
+        # Read coms_to_secrets (33*n bytes)
+        if len(rest) < 33 * n:
+            raise ValueError
+        coms_to_secrets, rest = (
+            [
+                GE.from_bytes_with_infinity(rest[i : i + 33])
+                for i in range(0, 33 * n, 33)
+            ],
+            rest[33 * n :],
+        )
+
+        # Read pops (64*n bytes)
+        if len(rest) < 64 * n:
+            raise ValueError
+        pops, rest = (
+            [Pop(rest[i : i + 64]) for i in range(len(rest) - 64 * n, len(rest), 64)],
+            rest[: len(rest) - 64 * n],
+        )
+
+        # Compute (t - 1)
+        t_minus_one, remainder = divmod(len(rest), 33)
+        if remainder != 0:
+            raise ValueError
+
+        # Read sum_coms_to_nonconst_terms (33*(t-1) bytes)
+        if len(rest) < 33 * t_minus_one:
+            raise ValueError
+        sum_coms_to_nonconst_terms, rest = (
+            [
+                GE.from_bytes_with_infinity(rest[i : i + 33])
+                for i in range(0, 33 * t_minus_one, 33)
+            ],
+            rest[33 * t_minus_one :],
+        )
+
+        if len(rest) != 0:
+            raise ValueError
+        return CoordinatorMsg(coms_to_secrets, sum_coms_to_nonconst_terms, pops)
+
 
 class CoordinatorInvestigationMsg(NamedTuple):
     partial_pubshares: List[GE]
+
+    def to_bytes(self) -> bytes:
+        return b"".join(
+            [P.to_bytes_compressed_with_infinity() for P in self.partial_pubshares]
+        )
+
+    @staticmethod
+    def from_bytes(b: bytes) -> CoordinatorInvestigationMsg:
+        rest = b
+
+        # Compute n
+        n, remainder = divmod(len(rest), 33)
+        if remainder != 0:
+            raise ValueError
+
+        # Read partial_pubshares (33*n bytes)
+        if len(rest) < 33 * n:
+            raise ValueError
+        partial_pubshares, rest = (
+            [
+                GE.from_bytes_with_infinity(rest[i : i + 33])
+                for i in range(0, 33 * n, 33)
+            ],
+            rest[33 * n :],
+        )
+
+        if len(rest) != 0:
+            raise ValueError
+        return CoordinatorInvestigationMsg(partial_pubshares)
 
 
 ###

--- a/python/example.py
+++ b/python/example.py
@@ -26,6 +26,7 @@ from chilldkg_ref.chilldkg import (
     FaultyParticipantOrCoordinatorError,
     UnknownFaultyParticipantOrCoordinatorError,
 )
+import chilldkg_ref.chilldkg as chilldkg
 
 #
 # Network mocks to simulate full DKG sessions
@@ -178,15 +179,17 @@ async def coordinator(
 async def faulty_participant(
     chan: ParticipantChannel, hostseckey: bytes, params: SessionParams, idx: int
 ):
+    n = len(params.hostpubkeys)
     random = random_bytes(32)
     _, pmsg1 = participant_step1(hostseckey, params, random)
+    pmsg1_parsed = chilldkg.ParticipantMsg1.from_bytes_and_n(pmsg1, n)
 
-    n = len(pmsg1.enc_pmsg.enc_shares)
+    assert len(pmsg1_parsed.enc_pmsg.enc_shares) == n
     # Pick random victim that is not this participant
     victim = (idx + randint(1, n - 1)) % n
-    pmsg1.enc_pmsg.enc_shares[victim] += 17
+    pmsg1_parsed.enc_pmsg.enc_shares[victim] += 17
 
-    chan.send(pmsg1)
+    chan.send(pmsg1_parsed.to_bytes())
 
 
 def simulate_chilldkg_full(

--- a/python/secp256k1lab/secp256k1.py
+++ b/python/secp256k1lab/secp256k1.py
@@ -373,6 +373,14 @@ class GE:
             return GE.from_bytes_uncompressed(b)
 
     @staticmethod
+    def from_bytes_with_infinity(b):
+        """Convert a compressed or uncompressed encoding to a group element, mapping zeros to infinity."""
+        if b == 33 * b"\x00":
+            return GE()
+        else:
+            return GE.from_bytes(b)
+
+    @staticmethod
     def from_bytes_xonly(b):
         """Convert a point given in xonly encoding to a group element."""
         assert len(b) == 32

--- a/python/tests.py
+++ b/python/tests.py
@@ -168,7 +168,11 @@ def simulate_encpedpop(
         for i in range(n):
             # Let a random participant faulty_idx[i] send incorrect shares to i.
             faulty_idx[i:] = [randint(0, n - 1)]
-            pmsgs[faulty_idx[i]].enc_shares[i] += Scalar(17)
+            faulty_pmsg = encpedpop.ParticipantMsg.from_bytes_and_n(
+                pmsgs[faulty_idx[i]], n
+            )
+            faulty_pmsg.enc_shares[i] += Scalar(17)
+            pmsgs[faulty_idx[i]] = faulty_pmsg.to_bytes()
 
     cmsg, cout, ceq, enc_secshares = encpedpop.coordinator_step(pmsgs, t, enckeys)
     pre_finalize_rets = [(cout, ceq)]
@@ -219,7 +223,11 @@ def simulate_chilldkg(
         for i in range(n):
             # Let a random participant faulty_idx[i] send incorrect shares to i.
             faulty_idx[i:] = [randint(0, n - 1)]
-            pmsgs[faulty_idx[i]].enc_pmsg.enc_shares[i] += Scalar(17)
+            faulty_pmsg = chilldkg.ParticipantMsg1.from_bytes_and_n(
+                pmsgs[faulty_idx[i]], n
+            )
+            faulty_pmsg.enc_pmsg.enc_shares[i] += Scalar(17)
+            pmsgs[faulty_idx[i]] = faulty_pmsg.to_bytes()
 
     cstate, cmsg1 = chilldkg.coordinator_step1(pmsgs, params)
 

--- a/update-pydoc.sh
+++ b/update-pydoc.sh
@@ -30,6 +30,12 @@ for name in SessionParams DKGOutput; do
         sed -n "/^class $name(NamedTuple):/,/^$/p" |
         # Remove docstring
         sed '/^ *"""/,/^ *"""/d' |
+        # Remove method header lines (starting with four spaces and then "def" or "@")
+        sed '/^    \(def\|@\)/d' |
+        # Remove method body lines (lines indented with 8 or more spaces)
+        sed '/^ \{8,\}/d' |
+        # Remove code comment lines
+        sed '/^    #/d' |
         # Remove trailing newline
         sed -z '$ s/\n$//' |
         # Do the patching


### PR DESCRIPTION
Addresses #25

This pull request updates ChillDKG APIs to serialize messages between participants and the coordinator as `bytes`. Specifically, these API input/output types have been updated to use `bytes`:

- `ParticipantMsg1`
- `ParticipantMsg2`
- `CoordinatorMsg1`
- `CoordinatorMsg2`
- `CoordinatorInvestigationMsg`

To support this, I've implemented `to_bytes()` and `from_bytes()` (or `from_bytes_and_n()`) methods for each named tuple. Additionally, I've introduced the `GE.from_bytes_with_infinity()` method.

## Alternative Designs

- **Including `n` in serialization**: Instead of using `from_bytes_and_n()`, we could encode `n` within the first four bytes of the serialization. This approach would remove the explicit `n` parameter. However, since we'd have to repeat this encoding at multiple layers (`chilldkg`, `encpedpop`, `simplepedpop`), it would result in redundant and less clean serialization.

- **Type Hinting and Aliases**: Currently, messages in API input/output are directly typed as `bytes`, which isn't ideal for type clarity. An alternative would be to create explicit aliases like `ParticipantMsg1Bytes` and `CoordinatorMsg1Bytes`, similar to what we have with `RecoveryData`. Another option would be to rename the current structured types (e.g., to `ParticipantMsg1Internal` or `ParticipantMsg1Struct`) and use the existing names as byte aliases.

## Questions

- Why does `VSSCommitment.from_bytes_and_t` explicitly require `t`? Can't we infer `t` by computing `len(b) // 33` like we do in `deserialize_recovery_data`? If this explicit approach was intentional, should we consistently implement explicit parameters (`from_bytes_and_t`) for other similar types, even when `t` can be inferred (e.g., `simplepedpop.ParticipantMsg.from_bytes`)?

- Currently, I've also implemented serialization/deserialization methods for `DKGOutput` and `SessionParams`. However, these types aren't actually exchanged between participants and the coordinator, so their serialization isn't used within the API inputs/outputs. Shall I remove these unused methods?

