### PR TITLE
Remove duplicate method & fix mypy error

### DIFF
--- a/python/secp256k1lab/src/secp256k1lab/secp256k1.py
+++ b/python/secp256k1lab/src/secp256k1lab/secp256k1.py
@@ -448,14 +448,6 @@ class GE:
             return 0  # 0 is not a valid x coordinate
         return int(self.x)
 
-    @staticmethod
-    def from_bytes_compressed_with_infinity(b):
-        """Convert a compressed to a group element, mapping zeros to infinity."""
-        if b == 33 * b"\x00":
-            return GE()
-        else:
-            return GE.from_bytes_compressed(b)
-
 
 # The secp256k1 generator point
 G = GE.lift_x(0x79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798)

--- a/python/tests.py
+++ b/python/tests.py
@@ -335,7 +335,9 @@ def test_correctness_dkg_output(t, n, dkg_outputs: List[simplpedpop.DKGOutput]):
         for secshare in secshares
     ]
     for i in range(1, n + 1):
-        assert secshares_scalar[i] * G == GE.from_bytes_compressed(pubshares[0][i - 1])
+        s = secshares_scalar[i]
+        assert s is not None
+        assert s * G == GE.from_bytes_compressed(pubshares[0][i - 1])
 
     # Check that all combinations of t participants can recover the threshold pubkey
     for tsubset in combinations(range(1, n + 1), t):


### PR DESCRIPTION
- Removed the duplicate `from_bytes_compressed_with_infinity` method in the `GE` class (introduced by mistake in #88)                                     
- Fixed mypy error by adding a type narrowing assert in `tests.py`. The error was thrown because `Scalar | None` type was being multplied with `GE`