### PR TITLE
Make *MsgParseError internal

### DIFF
--- a/README.md
+++ b/README.md
@@ -961,7 +961,6 @@ data, from which this participant can recover the DKG output using the
   investigation procedure of the protocol is necessary to determine a
   suspected participant. See the documentation of the exception for
   further details.
-- `CoordinatorMsgParseError` - If the coordinator message could not be parsed.
 
 #### participant\_finalize
 
@@ -1007,7 +1006,8 @@ recovery data to this participant.
 - `FaultyParticipantOrCoordinatorError` - If another known participant or the
   coordinator is faulty. Make sure to read the above warning, and see
   the documentation of the exception for further details.
-- `CoordinatorMsgParseError` - If the coordinator message could not be parsed.
+- `FaultyCoordinatorError` - If the coordinator is faulty. See the
+  documentation of the exception for further details.
 
 #### participant\_investigate
 
@@ -1039,8 +1039,6 @@ exceptions.
   further details.
 - `FaultyCoordinatorError` - If the coordinator is faulty. See the
   documentation of the exception for further details.
-- `CoordinatorMsgParseError` - If the investigation message could
-  not be parsed.
 
 #### coordinator\_step1
 
@@ -1074,7 +1072,6 @@ Perform the coordinator's first step of a ChillDKG session.
   not hold.
 - `FaultyParticipantError` - If another participant is faulty. See the
   documentation of the exception for further details.
-- `ParticipantMsgParseError` - If a participant message could not be parsed.
 
 #### coordinator\_finalize
 
@@ -1121,7 +1118,6 @@ other participants via a communication channel beside the coordinator.
 
 - `FaultyParticipantError` - If another participant is faulty. See the
   documentation of the exception for further details.
-- `ParticipantMsgParseError` - If a participant message could not be parsed.
 
 #### coordinator\_investigate
 
@@ -1152,7 +1148,8 @@ information.
 
 *Raises*:
 
-- `ParticipantMsgParseError` - If a participant message could not be parsed.
+- `FaultyParticipantError` - If another participant is faulty. See the
+  documentation of the exception for further details.
 
 #### recover
 
@@ -1297,26 +1294,6 @@ the coordinator (namely, sending invalid encrypted secret shares).
 *Attributes*:
 
 - `inv_data` - Information required to perform the investigation.
-
-#### ParticipantMsgParseError Exception
-
-```python
-class ParticipantMsgParseError(MsgParseError)
-```
-
-Raised when parsing a participant message fails.
-
-*Attributes*:
-
-- `participant` _int_ - Index of the participant whose message failed to parse.
-
-#### CoordinatorMsgParseError Exception
-
-```python
-class CoordinatorMsgParseError(MsgParseError)
-```
-
-Raised when parsing a coordinator message fails.
 <!--end of pydoc.md-->
 
 ## Changelog

--- a/python/chilldkg_ref/chilldkg.py
+++ b/python/chilldkg_ref/chilldkg.py
@@ -59,8 +59,6 @@ __all__ = [
     "FaultyCoordinatorError",
     "UnknownFaultyParticipantOrCoordinatorError",
     "RecoveryDataError",
-    "ParticipantMsgParseError",
-    "CoordinatorMsgParseError",
     # Types
     "SessionParams",
     "DKGOutput",
@@ -617,7 +615,6 @@ def participant_step2(
             investigation procedure of the protocol is necessary to determine a
             suspected participant. See the documentation of the exception for
             further details.
-        CoordinatorMsgParseError: If the coordinator message could not be parsed.
     """
     if len(hostseckey) != 32:
         raise HostSeckeyError
@@ -683,7 +680,8 @@ def participant_finalize(
         FaultyParticipantOrCoordinatorError: If another known participant or the
             coordinator is faulty. Make sure to read the above warning, and see
             the documentation of the exception for further details.
-        CoordinatorMsgParseError: If the coordinator message could not be parsed.
+        FaultyCoordinatorError: If the coordinator is faulty. See the
+            documentation of the exception for further details.
     """
     params, eq_input, dkg_output = state2
     try:
@@ -724,8 +722,6 @@ def participant_investigate(
             further details.
         FaultyCoordinatorError: If the coordinator is faulty. See the
             documentation of the exception for further details.
-        CoordinatorMsgParseError: If the investigation message could
-            not be parsed.
     """
     assert isinstance(error.inv_data, encpedpop.ParticipantInvestigationData)
     n = error.inv_data.simpl_bstate.n
@@ -774,7 +770,6 @@ def coordinator_step1(
             not hold.
         FaultyParticipantError: If another participant is faulty. See the
             documentation of the exception for further details.
-        ParticipantMsgParseError: If a participant message could not be parsed.
     """
     params_validate(params)
     hostpubkeys, t = params
@@ -839,7 +834,6 @@ def coordinator_finalize(
     Raises:
         FaultyParticipantError: If another participant is faulty. See the
             documentation of the exception for further details.
-        ParticipantMsgParseError: If a participant message could not be parsed.
     """
     params, eq_input, dkg_output = state
     if len(pmsgs2) != len(params.hostpubkeys):
@@ -883,7 +877,8 @@ def coordinator_investigate(pmsgs: List[bytes], params: SessionParams) -> List[b
             participant.
 
     Raises:
-        ParticipantMsgParseError: If a participant message could not be parsed.
+        FaultyParticipantError: If another participant is faulty. See the
+            documentation of the exception for further details.
     """
     n = len(pmsgs)
     t = params.t

--- a/python/chilldkg_ref/util.py
+++ b/python/chilldkg_ref/util.py
@@ -104,20 +104,12 @@ class UnknownFaultyParticipantOrCoordinatorError(ProtocolError):
 
 
 class MsgParseError(ValueError):
-    """Raised when parsing a serialized message fails."""
+    pass
 
 
-class ParticipantMsgParseError(MsgParseError):
-    """Raised when parsing a participant message fails.
-
-    Attributes:
-        participant (int): Index of the participant whose message failed to parse.
-    """
-
-    def __init__(self, participant: int, *args: Any):
-        self.participant = participant
-        super().__init__(participant, *args)
+class ParticipantMsgParseError(FaultyParticipantError):
+    pass
 
 
-class CoordinatorMsgParseError(MsgParseError):
-    """Raised when parsing a coordinator message fails."""
+class CoordinatorMsgParseError(FaultyCoordinatorError):
+    pass

--- a/update-pydoc.sh
+++ b/update-pydoc.sh
@@ -15,9 +15,7 @@ pydoc-markdown -I python/chilldkg_ref -m "$module" "{renderer: {type: markdown, 
     sed -z 's/Error Tuples/Error Exception/g' |
     # Replace bold (**) by italics (*), but not for **must**, **must not**,
     # **should**, or **should not**.
-    python3 -c "import re, sys; sys.stdout.write(re.sub(r'\*\*(?!must\*\*|should\*\*|must not\*\*|should not\*\*)(.*?)\*\*', r'*\1*', sys.stdin.read()))" |
-    # Remove MsgParseError section (internal class, not part of public API)
-    sed -z 's/#### MsgParseError Exception[^#]*####/####/' >> pydoc.md
+    python3 -c "import re, sys; sys.stdout.write(re.sub(r'\*\*(?!must\*\*|should\*\*|must not\*\*|should not\*\*)(.*?)\*\*', r'*\1*', sys.stdin.read()))" >> pydoc.md
 
 done
 


### PR DESCRIPTION
As suggested in https://github.com/BlockstreamResearch/bip-frost-dkg/pull/88#issuecomment-3822647429, this pull request makes the `ParticipantMsgParseError` and `CoordinatorMsgParseError` internal. Users catch these exceptions as `FaultyParticipantError` and `FaultyCoordinatorError` respectively.