### PR TITLE
Expose `aux_rand` to ChillDKG APIs for derterministic behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -915,7 +915,7 @@ Raised if the length of the provided randomness is not 32 bytes.
 #### participant\_step2
 
 ```python
-def participant_step2(hostseckey: bytes, state1: ParticipantState1, cmsg1: bytes) -> Tuple[ParticipantState2, bytes]
+def participant_step2(hostseckey: bytes, state1: ParticipantState1, cmsg1: bytes, aux_rand: bytes) -> Tuple[ParticipantState2, bytes]
 ```
 
 Perform a participant's second step of a ChillDKG session.
@@ -938,6 +938,9 @@ data, from which this participant can recover the DKG output using the
 - `state1` - The participant's session state as output by
   `participant_step1`.
 - `cmsg1` - The first message received from the coordinator.
+- `aux_rand` - Auxiliary randomness (32 bytes). FRESH 32-byte randomness
+  is optimal, but 16 random bytes or a counter padded to 32 bytes
+  is acceptable (see BIP 340).
 
 
 *Returns*:
@@ -952,6 +955,7 @@ data, from which this participant can recover the DKG output using the
 *Raises*:
 
 - `HostSeckeyError` - If the length of `hostseckey` is not 32 bytes.
+- `RandomnessError` - If the length of `aux_rand` is not 32 bytes.
 - `FaultyCoordinatorError` - If the coordinator is faulty. See the
   documentation of the exception for further details.
 - `FaultyParticipantOrCoordinatorError` - If another known participant or the

--- a/python/chilldkg_ref/chilldkg.py
+++ b/python/chilldkg_ref/chilldkg.py
@@ -10,7 +10,6 @@ their arguments and return values, and the exceptions they raise; see also the
 
 from __future__ import annotations
 
-from secrets import token_bytes as random_bytes
 from typing import Any, Tuple, List, NamedTuple, NewType, Optional, NoReturn, Dict
 
 from secp256k1lab.secp256k1 import Scalar, GE
@@ -88,9 +87,11 @@ def certeq_message(x: bytes, idx: int) -> bytes:
     return prefix + idx.to_bytes(4, "big") + x
 
 
-def certeq_participant_step(hostseckey: bytes, idx: int, x: bytes) -> bytes:
+def certeq_participant_step(
+    hostseckey: bytes, idx: int, x: bytes, aux_rand: bytes
+) -> bytes:
     msg = certeq_message(x, idx)
-    return schnorr_sign(msg, hostseckey, aux_rand=random_bytes(32))
+    return schnorr_sign(msg, hostseckey, aux_rand=aux_rand)
 
 
 def certeq_cert_len(n: int) -> int:
@@ -577,6 +578,7 @@ def participant_step2(
     hostseckey: bytes,
     state1: ParticipantState1,
     cmsg1: bytes,
+    aux_rand: bytes,
 ) -> Tuple[ParticipantState2, bytes]:
     """Perform a participant's second step of a ChillDKG session.
 
@@ -597,6 +599,9 @@ def participant_step2(
         state1: The participant's session state as output by
             `participant_step1`.
         cmsg1: The first message received from the coordinator.
+        aux_rand: Auxiliary randomness (32 bytes). FRESH 32-byte randomness
+            is optimal, but 16 random bytes or a counter padded to 32 bytes
+            is acceptable (see BIP 340).
 
     Returns:
         ParticipantState2: The participant's session state after this step, to
@@ -607,6 +612,7 @@ def participant_step2(
 
     Raises:
         HostSeckeyError: If the length of `hostseckey` is not 32 bytes.
+        RandomnessError: If the length of `aux_rand` is not 32 bytes.
         FaultyCoordinatorError: If the coordinator is faulty. See the
             documentation of the exception for further details.
         FaultyParticipantOrCoordinatorError: If another known participant or the
@@ -621,6 +627,8 @@ def participant_step2(
     """
     if len(hostseckey) != 32:
         raise HostSeckeyError
+    if len(aux_rand) != 32:
+        raise RandomnessError
 
     params, idx, enc_state = state1
     t = enc_state.simpl_state.t
@@ -642,7 +650,7 @@ def participant_step2(
     eq_input += b"".join([bytes_from_int(int(share)) for share in enc_secshares])
     dkg_output = DKGOutput._make(enc_dkg_output)
     state2 = ParticipantState2(params, eq_input, dkg_output)
-    sig = certeq_participant_step(hostseckey, idx, eq_input)
+    sig = certeq_participant_step(hostseckey, idx, eq_input, aux_rand)
     pmsg2 = ParticipantMsg2(sig).to_bytes()
     return state2, pmsg2
 

--- a/python/chilldkg_ref/encpedpop.py
+++ b/python/chilldkg_ref/encpedpop.py
@@ -370,7 +370,7 @@ def participant_step2(
         # Translate simplpedpop.ParticipantInvestigationData into our own
         # encpedpop.ParticipantInvestigationData.
         inv_data = ParticipantInvestigationData(e.inv_data, enc_secshare, pads)
-        raise UnknownFaultyParticipantOrCoordinatorError(inv_data, e.args) from e
+        raise UnknownFaultyParticipantOrCoordinatorError(inv_data, *e.args) from e
 
     eq_input += b"".join(enckeys) + b"".join(pubnonces)
     return dkg_output, eq_input

--- a/python/chilldkg_ref/encpedpop.py
+++ b/python/chilldkg_ref/encpedpop.py
@@ -322,11 +322,12 @@ def participant_step1(
     # derive the nonce from simpl_seed.
     enc_context = serialize_enc_context(t, enckeys)
     simpl_seed = tagged_hash_bip_dkg("encpedpop seed", seed + random + enc_context)
+    simpl_aux_rand = tagged_hash_bip_dkg("simplpedpop aux", simpl_seed)
     secnonce = tagged_hash_bip_dkg("encpedpop secnonce", simpl_seed)
     pubnonce = pubkey_gen_plain(secnonce)
 
     simpl_state, simpl_pmsg, shares = simplpedpop.participant_step1(
-        simpl_seed, t, n, idx
+        simpl_seed, t, n, idx, simpl_aux_rand
     )
     assert len(shares) == n
 

--- a/python/example.py
+++ b/python/example.py
@@ -125,7 +125,8 @@ async def participant(
         cinv = await chan.receive()
 
     try:
-        state2, eq_round1 = participant_step2(hostseckey, state1, cmsg1)
+        random = random_bytes(32)
+        state2, eq_round1 = participant_step2(hostseckey, state1, cmsg1, random)
     except UnknownFaultyParticipantOrCoordinatorError as e:
         if investigation_procedure:
             participant_investigate(e, cinv)

--- a/python/tests.py
+++ b/python/tests.py
@@ -101,7 +101,8 @@ def simulate_simplpedpop(
     n = len(seeds)
     prets = []
     for i in range(n):
-        prets += [simplpedpop.participant_step1(seeds[i], t, n, i)]
+        random = random_bytes(32)
+        prets += [simplpedpop.participant_step1(seeds[i], t, n, i, random)]
 
     pstates = [pstate for (pstate, _, _) in prets]
     pmsgs = [pmsg for (_, pmsg, _) in prets]
@@ -236,7 +237,10 @@ def simulate_chilldkg(
     prets2 = []
     for i in range(n):
         try:
-            prets2 += [chilldkg.participant_step2(hostseckeys[i], pstates1[i], cmsg1)]
+            random = random_bytes(32)
+            prets2 += [
+                chilldkg.participant_step2(hostseckeys[i], pstates1[i], cmsg1, random)
+            ]
         except UnknownFaultyParticipantOrCoordinatorError as e:
             if not investigation:
                 raise


### PR DESCRIPTION
Fixes #86 

Modified ChillDKG APIs to accept randomness parameters rather than generating new randomness internally. This enables deterministic behavior when needed (e.g., for test vectors).                                                                                                             

- Add `random` parameter to `pop_prove()` and `certeq_participant_step()`
- Add `random` parameter to `simplpedpop.participant_step1()` and `chilldkg.participant_step2()`
- Update tests and example code to use new APIs 
- Fix `e.args` unpacking in encpedpop