### PR TITLE
Remove InvalidSignatureInCertificateError from public API

### DIFF
--- a/python/chilldkg_ref/chilldkg.py
+++ b/python/chilldkg_ref/chilldkg.py
@@ -45,7 +45,6 @@ __all__ = [
     "coordinator_investigate",
     "recover",
     # Exceptions
-    "InvalidSignatureInCertificateError",
     "HostSeckeyError",
     "SessionParamsError",
     "InvalidHostPubkeyError",


### PR DESCRIPTION
Removes `InvalidSignatureInCertificateError` from `__all__` since it's an internal exception that is only raised by the internal `certeq_verify` function.