### PR TITLE
python: Add coverage tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ wheels/
 
 # Virtual environments
 .venv
+
+# Coverage data
+.coverage
+htmlcov/

--- a/python/coverage.sh
+++ b/python/coverage.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+
+command -v coverage > /dev/null 2>&1 || {
+  echo >&2 "coverage is required but it's not installed. Aborting."
+  exit 1
+}
+
+cd "$(dirname "$0")"
+
+coverage run --branch --source=chilldkg_ref tests.py
+coverage report -m
+coverage html


### PR DESCRIPTION
Add optional branch coverage reporting via `coverage.sh`. Running it produces a terminal summary and an HTML report (`htmlcov/index.html`) with uncovered lines highlighted. Coverage is scoped to `chilldkg_ref` only.