### PR TITLE
python: Fix wrong-length tests in test_recovery_acknowledgment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1251,13 +1251,12 @@ successfully received the complete recovery data.
 
 *Raises*:
 
-- `HostSeckeyError` - If the length of `hostseckey` is not 32 bytes, if the
-  key is invalid, or if the key does not match any host public key.
+- `HostSeckeyError` - If the host secret key is invalid, or if it does not match
+  any host public key.
 - `InvalidHostPubkeyError` - If `hostpubkeys` contains an invalid public key.
 - `DuplicateHostPubkeyError` - If `hostpubkeys` contains duplicates.
 - `ThresholdOrCountError` - If `1 <= t <= len(hostpubkeys) <= 2**32 - 1` does
   not hold.
-- `RandomnessError` - If the length of `aux_rand` is not 32 bytes.
 - `RecoveryDataError` - If the recovery data is invalid or does not match
   the provided parameters.
 

--- a/python/chilldkg_ref/chilldkg.py
+++ b/python/chilldkg_ref/chilldkg.py
@@ -141,9 +141,7 @@ def recovery_ack_message(x: bytes, idx: int) -> bytes:
     return prefix + idx.to_bytes(4, "big") + x
 
 
-def recovery_ack_sign(
-    hostseckey: bytes, idx: int, x: bytes, aux_rand: bytes
-) -> bytes:
+def recovery_ack_sign(hostseckey: bytes, idx: int, x: bytes, aux_rand: bytes) -> bytes:
     msg = recovery_ack_message(x, idx)
     return schnorr_sign(msg, hostseckey, aux_rand=aux_rand)
 
@@ -1058,7 +1056,10 @@ class RecoveryDataError(ValueError):
 
 
 def participant_recovery_ack_sign(
-    hostseckey: bytes, recovery_data: RecoveryData, params: SessionParams, aux_rand: bytes
+    hostseckey: bytes,
+    recovery_data: RecoveryData,
+    params: SessionParams,
+    aux_rand: bytes,
 ) -> bytes:
     """Sign recovery data to create a recovery acknowledgment.
 
@@ -1079,17 +1080,16 @@ def participant_recovery_ack_sign(
         bytes: Acknowledgment signature (64 bytes).
 
     Raises:
-        HostSeckeyError: If the length of `hostseckey` is not 32 bytes, if the
-            key is invalid, or if the key does not match any host public key.
+        HostSeckeyError: If the host secret key is invalid, or if it does not match
+            any host public key.
         InvalidHostPubkeyError: If `hostpubkeys` contains an invalid public key.
         DuplicateHostPubkeyError: If `hostpubkeys` contains duplicates.
         ThresholdOrCountError: If `1 <= t <= len(hostpubkeys) <= 2**32 - 1` does
             not hold.
-        RandomnessError: If the length of `aux_rand` is not 32 bytes.
         RecoveryDataError: If the recovery data is invalid or does not match
             the provided parameters.
     """
-    hostpubkey = hostpubkey_gen(hostseckey)  # HostSeckeyError if len(hostseckey) != 32
+    hostpubkey = hostpubkey_gen(hostseckey)  # ValueError if len(hostseckey) != 32
 
     params_validate(params)
     (hostpubkeys, t) = params
@@ -1101,7 +1101,7 @@ def participant_recovery_ack_sign(
             "Host secret key does not match any host public key"
         ) from e
     if len(aux_rand) != 32:
-        raise RandomnessError
+        raise ValueError
 
     try:
         (t_rec, _, hostpubkeys_rec, _, _, _) = deserialize_recovery_data(recovery_data)

--- a/python/chilldkg_ref/chilldkg.py
+++ b/python/chilldkg_ref/chilldkg.py
@@ -74,6 +74,7 @@ __all__ = [
     "CoordinatorMsg1",
     "CoordinatorMsg2",
     "CoordinatorState",
+    "RecoveryAckMsg",
     "RecoveryData",
 ]
 
@@ -465,6 +466,19 @@ class CoordinatorInvestigationMsg(NamedTuple):
             b, n
         )  # MsgParseError if invalid
         return CoordinatorInvestigationMsg(enc_cinv)
+
+
+class RecoveryAckMsg(NamedTuple):
+    sig: bytes
+
+    def to_bytes(self) -> bytes:
+        return self.sig
+
+    @staticmethod
+    def from_bytes(b: bytes) -> RecoveryAckMsg:
+        if len(b) != 64:
+            raise MsgParseError("invalid recovery acknowledgment signature length")
+        return RecoveryAckMsg(b)
 
 
 def deserialize_recovery_data(
@@ -1114,7 +1128,8 @@ def participant_recovery_ack_sign(
         )
 
     sig = recovery_ack_sign(hostseckey, idx, recovery_data, aux_rand)
-    return sig
+    rmsg = RecoveryAckMsg(sig).to_bytes()
+    return rmsg
 
 
 def participant_recovery_acks_verify(
@@ -1162,13 +1177,15 @@ def participant_recovery_acks_verify(
         )
 
     for i, sig in enumerate(ack_sigs):
-        if len(sig) != 64:
-            raise InvalidRecoveryAckError(i)
+        try:
+            rmsg = RecoveryAckMsg.from_bytes(sig)
+        except MsgParseError as e:
+            raise InvalidRecoveryAckError(i) from e
         msg = recovery_ack_message(recovery_data, i)
         valid = schnorr_verify(
             msg,
             hostpubkeys[i][1:33],
-            sig,
+            rmsg.sig,
         )
         if not valid:
             raise InvalidRecoveryAckError(i)

--- a/python/tests.py
+++ b/python/tests.py
@@ -716,7 +716,6 @@ def test_recovery_acknowledgment():
 
     results = simulate_chilldkg(hostseckeys, t, investigation=False)
     recovery_data = results[1][1]  # First participant's recovery data
-    dkg_outputs = [result[0] for result in results[1:]]  # All participants' DKG outputs
 
     ack_sigs = []
     for i in range(n):
@@ -730,8 +729,10 @@ def test_recovery_acknowledgment():
 
     # Wrong hostseckey length
     try:
-        chilldkg.participant_recovery_ack_sign(random_bytes(16), recovery_data, params, random_bytes(32))
-    except chilldkg.HostSeckeyError:
+        chilldkg.participant_recovery_ack_sign(
+            random_bytes(16), recovery_data, params, random_bytes(32)
+        )
+    except ValueError:
         pass
     else:
         assert False, "Expected exception"
@@ -740,14 +741,18 @@ def test_recovery_acknowledgment():
     invalid_hostpubkey = b"\x03" + 31 * b"\x00" + b"\x05"
     invalid_params = chilldkg.SessionParams([hostpubkeys[0], invalid_hostpubkey], t)
     try:
-        chilldkg.participant_recovery_ack_sign(hostseckeys[0], recovery_data, invalid_params, random_bytes(32))
+        chilldkg.participant_recovery_ack_sign(
+            hostseckeys[0], recovery_data, invalid_params, random_bytes(32)
+        )
     except chilldkg.InvalidHostPubkeyError:
         pass
     else:
         assert False, "Expected exception"
 
     try:
-        chilldkg.participant_recovery_acks_verify(recovery_data, invalid_params, ack_sigs)
+        chilldkg.participant_recovery_acks_verify(
+            recovery_data, invalid_params, ack_sigs
+        )
     except chilldkg.InvalidHostPubkeyError:
         pass
     else:
@@ -756,7 +761,9 @@ def test_recovery_acknowledgment():
     # Duplicate hostpubkey in params
     invalid_params = chilldkg.SessionParams([hostpubkeys[0], hostpubkeys[0]], t)
     try:
-        chilldkg.participant_recovery_ack_sign(hostseckeys[0], recovery_data, invalid_params, random_bytes(32))
+        chilldkg.participant_recovery_ack_sign(
+            hostseckeys[0], recovery_data, invalid_params, random_bytes(32)
+        )
     except chilldkg.DuplicateHostPubkeyError:
         pass
     else:
@@ -765,7 +772,9 @@ def test_recovery_acknowledgment():
     # Invalid threshold in params
     invalid_params = chilldkg.SessionParams(hostpubkeys, n + 1)
     try:
-        chilldkg.participant_recovery_ack_sign(hostseckeys[0], recovery_data, invalid_params, random_bytes(32))
+        chilldkg.participant_recovery_ack_sign(
+            hostseckeys[0], recovery_data, invalid_params, random_bytes(32)
+        )
     except chilldkg.ThresholdOrCountError:
         pass
     else:
@@ -773,7 +782,9 @@ def test_recovery_acknowledgment():
 
     # Wrong hostseckey
     try:
-        chilldkg.participant_recovery_ack_sign(random_bytes(32), recovery_data, params, random_bytes(32))
+        chilldkg.participant_recovery_ack_sign(
+            random_bytes(32), recovery_data, params, random_bytes(32)
+        )
     except chilldkg.HostSeckeyError:
         pass
     else:
@@ -781,8 +792,10 @@ def test_recovery_acknowledgment():
 
     # Invalid randomness length
     try:
-        chilldkg.participant_recovery_ack_sign(hostseckeys[0], recovery_data, params, random_bytes(16))
-    except chilldkg.RandomnessError:
+        chilldkg.participant_recovery_ack_sign(
+            hostseckeys[0], recovery_data, params, random_bytes(16)
+        )
+    except ValueError:
         pass
     else:
         assert False, "Expected exception"
@@ -790,14 +803,18 @@ def test_recovery_acknowledgment():
     # Mismatched params
     invalid_params = chilldkg.SessionParams(hostpubkeys, t + 1)
     try:
-        chilldkg.participant_recovery_ack_sign(hostseckeys[0], recovery_data, invalid_params, random_bytes(32))
+        chilldkg.participant_recovery_ack_sign(
+            hostseckeys[0], recovery_data, invalid_params, random_bytes(32)
+        )
     except chilldkg.RecoveryDataError:
         pass
     else:
         assert False, "Expected exception"
 
     try:
-        chilldkg.participant_recovery_acks_verify(recovery_data, invalid_params, ack_sigs)
+        chilldkg.participant_recovery_acks_verify(
+            recovery_data, invalid_params, ack_sigs
+        )
     except chilldkg.RecoveryDataError:
         pass
     else:
@@ -806,14 +823,18 @@ def test_recovery_acknowledgment():
     # Corrupted recovery data
     corrupted_recovery_data = random_bytes(len(recovery_data))
     try:
-        chilldkg.participant_recovery_ack_sign(hostseckeys[0], corrupted_recovery_data, params, random_bytes(32))
+        chilldkg.participant_recovery_ack_sign(
+            hostseckeys[0], corrupted_recovery_data, params, random_bytes(32)
+        )
     except chilldkg.RecoveryDataError:
         pass
     else:
         assert False, "Expected exception"
 
     try:
-        chilldkg.participant_recovery_acks_verify(corrupted_recovery_data, params, ack_sigs)
+        chilldkg.participant_recovery_acks_verify(
+            corrupted_recovery_data, params, ack_sigs
+        )
     except chilldkg.RecoveryDataError:
         pass
     else:
@@ -823,7 +844,9 @@ def test_recovery_acknowledgment():
     invalid_ack_sigs = ack_sigs[:]
     invalid_ack_sigs[1] = random_bytes(64)
     try:
-        chilldkg.participant_recovery_acks_verify(recovery_data, params, invalid_ack_sigs)
+        chilldkg.participant_recovery_acks_verify(
+            recovery_data, params, invalid_ack_sigs
+        )
     except chilldkg.InvalidRecoveryAckError as e:
         assert e.participant == 1
     else:
@@ -833,9 +856,22 @@ def test_recovery_acknowledgment():
     wrong_length_sigs = ack_sigs[:]
     wrong_length_sigs[0] = random_bytes(32)
     try:
-        chilldkg.participant_recovery_acks_verify(recovery_data, params, wrong_length_sigs)
+        chilldkg.participant_recovery_acks_verify(
+            recovery_data, params, wrong_length_sigs
+        )
     except chilldkg.InvalidRecoveryAckError as e:
         assert e.participant == 0
+    else:
+        assert False, "Expected exception"
+
+    # Wrong number of signatures
+    wrong_count_sigs = ack_sigs[:-1]  # n-1 instead of n
+    try:
+        chilldkg.participant_recovery_acks_verify(
+            recovery_data, params, wrong_count_sigs
+        )
+    except ValueError:
+        pass
     else:
         assert False, "Expected exception"
 


### PR DESCRIPTION
Merging #106 (recovery acknowledgment) after #118, left some logic in test_recovery_acknowledgment outdated.
