### PR TITLE
Rewrite "setup", mention BIP445, clarify 0-based indices 

### DIFF
--- a/README.md
+++ b/README.md
@@ -603,21 +603,23 @@ ChillDKG provides optional functionality for creating and verifying acknowledgme
 ### Blaming Faulty Parties
 
 Any faulty party can make a ChillDKG session abort by sending a message that deviates from the protocol specification.
-To help resolve the underlying problem, ChillDKG provides a *blame functionality*
-that enables honest protocol parties to identify and blame at least one participant suspected to be faulty:
+In order to resolve such situations, ChillDKG offers a *blame functionality*.
+Under the assumption that communication links are reliable,
+the blame functionality enables honest protocol parties to identify and blame at least one participant suspected to be faulty:
  - If an honest participant aborts the session, then this participant will blame at least one participant or the coordinator.
  - If an honest coordinator aborts the session, then the coordinator will blame at least one participant.
 
-Moreover, a party which, instead of aborting after having received an invalid protocol message,
-aborts due to a timeout while waiting for a protocol message
+Moreover, a party which aborts due to a timeout while waiting for a protocol message
+(instead of aborting after having received an invalid protocol message)
 will trivially blame the party who is supposed to send the outstanding message.
 
 The guarantees provided by the blame functionality are limited,
 and its primary purpose is to support manual investigation and debugging efforts.
 Different parties, even if honest, are not guaranteed to blame the same party,
 and there is, in general, no way to verify an accusation by some party that another party is to blame.
-Nevertheless, if all messages in the ChillDKG session have been transmitted correctly over the communication links,
-and, in case of a participant blaming another participant, if the coordinator is additionally honest,
+
+Nevertheless, under the condition that all messages in the ChillDKG session have been transmitted correctly over the communication links,
+and, in case of a participant blaming another participant, under the additional condition that the coordinator is honest,
 the aborting party will be guaranteed that the blamed party is indeed faulty.
 
 It is important to understand that this guarantee is conditional.

--- a/README.md
+++ b/README.md
@@ -402,15 +402,6 @@ and it repurposes the host secret key as the seed required by EncPedPop.
 [^joint-security]: Schnorr signatures and ECDH-based KEMs are known to be jointly secure [Theorem 2, [DLPSS11](https://eprint.iacr.org/2011/615)]
 under the combination of the gap-DH and gap-DL assumptions, and this result can be adapted to the MR-KEM used in EncPedPop.
 
-ChillDKG requires that all participants have authentic copies of the other participants' host public keys.[^trust-anchor]
-Authenticity of the host public keys can be verified through pairwise out-of-band comparisons between every pair of participants.
-This verification can occur at any time before the DKG session is finalized, in particular before the start of the session.
-
-[^trust-anchor]: No protocol can prevent man-in-the-middle attacks without this or a comparable assumption.
-Note that this requirement is implicit in other schemes as well.
-For example, setting up a multi-signature wallet via non-interactive key aggregation in MuSig2 [[BIP 327](https://github.com/bitcoin/bips/blob/master/bip-0327.mediawiki)]
-also requires the assumption that all participants have authentic copies of each other's individual public keys.
-
 #### Equality Check Protocol CertEq
 
 The CertEq protocol is straightforward:[^certeq-literature]
@@ -436,7 +427,7 @@ The key insight to ensuring conditional agreement is that any participant termin
 obtains a *success certificate* `cert` consisting of the collected list of all `n` signatures on `eq_input`.
 This certificate will, by the above termination rule, convince every other honest participant (who, by integrity, has received `eq_input` as input) to terminate successfully.
 Crucially, this other honest participant will be convinced even after having received invalid or no signatures during the actual run of CertEq,
-due to unreliable networks, a faulty coordinator, or faulty participants signing more than one value.
+due to unreliable communication links, a faulty coordinator, or faulty participants signing more than one value.
 
 Thus, the certificate does not need to be sent during a normal run of CertEq,
 but can instead be presented to other participants later,
@@ -487,21 +478,44 @@ without careful further consideration, which is not in the scope of this documen
 
 [^no-simulatable-dkg]: As a variant of Pedersen DKG, ChillDKG does not provide simulation-based security [GJKR07](https://doi.org/10.1007/s00145-006-0347-3). Roughly speaking, if ChillDKG is combined with some threshold cryptographic scheme, the security of the combination is not automatically implied by the security of the two components. Instead, the security of every combination must be analyzed separately. The security of the specific combination of SimplPedPop (as the core building block of ChillDKG) and FROST has been analyzed [CGRS23](https://eprint.iacr.org/2023/899).
 
-### Protocol Parties and Network Setup
+### DKG Parties and Inputs
 
-There are `n >= 1` *participants*, `t` of which will be required to produce a signature.
-Each participant has a point-to-point communication link to the *coordinator*
-(but participants do not have direct communication links to each other).
-
+A DKG session comprises `n >= 1` *participants*,
+some number `t <= n` of which will be required to produce a signature.
+Additionally, each session requires a helper party called the *coordinator*.
 If there is no dedicated coordinator, one of the participants can act as the coordinator.
 
-Each participant and the coordinator, and the communication links may either be *honest*, i.e., reliable and adhering to the protocol, or *faulty*, i.e., controlled by an attacker or unreliable (e.g., due to software bugs).
+Each participant holds a long-term *host key pair* consisting of a *host public key* and a *host secret key*.
+The `n` participants in a DKG session are represented by an ordered list of their host public keys.
+The list must not contain duplicate entries,
+and thus the list assigns each participant a unique index in the range of `0` to `n - 1` according to the position of their host public key in the list.
 
-### Inputs and Output
+The list of host public keys and the signing threshold `t` together
+form the public *session parameters*, the common input to all participants and the coordinator.
 
-The inputs of a session consist of a long-term *host secret key* (individual to each participant, not provided by the coordinator) and public *session parameters* (common to all participants and the coordinator).
+ChillDKG requires that all participants have authentic copies of all other participants' host public keys.[^trust-anchor]
+Authenticity of the host public keys can be verified through pairwise out-of-band comparisons between every pair of participants.
+This verification can occur at any time before the DKG session is finalized, in particular before the start of the session.
 
-If a session ChillDKG returns an output to a participant or the coordinator,
+[^trust-anchor]: No protocol can prevent man-in-the-middle attacks without this or a comparable assumption.
+Note that this requirement is implicit in other schemes as well.
+For example, setting up a multi-signature wallet via non-interactive key aggregation in MuSig2 [[BIP 327](https://github.com/bitcoin/bips/blob/master/bip-0327.mediawiki)]
+also requires the assumption that all participants have authentic copies of each other's individual public keys.
+
+Each party (i.e., participant or coordinator) is assumed to be either *honest* (i.e., reliable and adhering to the protocol)
+or *faulty* (i.e., controlled by an attacker or defective).
+
+### Network Setup
+
+Each participant has a point-to-point communication link to the coordinator
+(but participants do not need direct communication links to each other).
+
+Transmission errors may hamper functionality (i.e., a DKG session may fail),
+but even an attacker in full control of communication links will not be able to hamper security.
+
+### DKG Outputs
+
+If a ChillDKG session returns an output to a participant or the coordinator,
 then we say that this party *deems the protocol session successful*.
 In that case, the DKG output is a triple consisting of a *secret share* for participating in FROST signing sessions (individual to each participant, not returned to the coordinator), the *threshold public key* representing the `t`-of-`n` policy of the group (common to all participants and the coordinator), and a list of `n` *public shares* for verification of individual contributions to a FROST signing session (common to all participants and the coordinator).
 Moreover, all parties obtain *recovery data* (common to all participants and the coordinator), whose purpose is detailed in the next subsection.
@@ -618,7 +632,7 @@ in order to single out and blame another participant (see [Overview of a ChillDK
 ### Threat Model and Security Goals
 
 We expect ChillDKG to provide the following informal security goals when it is used to set up keys for the FROST threshold signature scheme.
-If a participant deems a protocol session successful (as defined in [Inputs and Output](#inputs-and-output)), then this participant is assured that:
+If a participant deems a protocol session successful (as defined in [DKG Outputs](#dkg-outputs)), then this participant is assured that:
  - A coalition of at most `t - 1` faulty participants and a faulty coordinator cannot forge a signature under the returned threshold public key on any message `m` for which no signing session with at least one honest participant was initiated. (Unforgeability)[^unforgeability-formal]
  - All honest participants who deem the protocol session successful will have correct and consistent protocol outputs.
    In particular, they agree on the threshold public key, the list of public shares, and the recovery data.

--- a/README.md
+++ b/README.md
@@ -28,20 +28,21 @@ The accompanying source code is licensed under the [MIT license](https://opensou
 
 ### Motivation
 
-The FROST signature scheme [[KG20](https://eprint.iacr.org/2020/852), [CKM21](https://eprint.iacr.org/2021/1375), [BTZ21](https://eprint.iacr.org/2022/833), [CGRS23](https://eprint.iacr.org/2023/899)] enables `t`-of-`n` Schnorr threshold signatures,
+The FROST threshold signature scheme [[KG20](https://eprint.iacr.org/2020/852), [CKM21](https://eprint.iacr.org/2021/1375), [BTZ21](https://eprint.iacr.org/2022/833), [CGRS23](https://eprint.iacr.org/2023/899)] enables `t`-of-`n` Schnorr signatures,
 in which some threshold `t` of a group of `n` participants is required to produce a signature.
-FROST remains unforgeable as long as at most `t-1` participants are compromised
-and remain functional as long as `t` honest participants do not lose their secret key material.
-Notably, FROST can be made compatible with [BIP 340](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki) Schnorr signatures and does not put any restrictions on the choice of `t` and `n` (as long as `1 <= t <= n`).[^t-edge-cases]
+FROST guarantees unforgeability as long as at most `t - 1` participants are compromised
+and remains functional as long as `t` honest participants do not lose their secret key material,
+where `t` and `n` can be chosen arbitrarily (as long as `1 <= t <= n`).[^t-edge-cases]
+As a result, threshold signatures increase both security and availability,
+enabling users to escape the inherent dilemma between the contradicting goals of protecting a single secret key against theft and data loss simultaneously.
 
 [^t-edge-cases]: While `t = n` and `t = 1` are in principle supported, simpler alternatives are available in these cases.
 In the case of `t = n`, using a dedicated `n`-of-`n` multi-signature scheme such as MuSig2 [[BIP 327](https://github.com/bitcoin/bips/blob/master/bip-0327.mediawiki)] instead of FROST avoids the need for an interactive DKG.
 The case `t = 1` can be realized by letting one participant generate an ordinary [BIP 340](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki) key pair and transmitting the key pair to every other participant, who can check its consistency and then simply use the ordinary [BIP 340](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki) signing algorithm.
 Participants still need to ensure that they agree on a key pair. A detailed specification is not in the scope of this document.
 
-As a result, threshold signatures increase both security and availability,
-enabling users to escape the inherent dilemma between the contradicting goals of protecting a single secret key against theft and data loss simultaneously.
-Before being able to create signatures, the participants need to generate a shared *threshold public key* (representing the entire group with its `t`-of-`n` policy),
+[BIP 445](https://github.com/bitcoin/bips/blob/master/bip-0445.md) provides a specification of the FROST signing protocol tailored to [BIP 340](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki) Schnorr signatures as deployed in Bitcoin.
+However, in order to use the specified protocol, the participants need to generate a shared *threshold public key* (representing the entire group with its `t`-of-`n` policy),
 together with `n` corresponding *secret shares* (held by the `n` participants) that allow to sign under the threshold public key.
 This key generation can, in principle, be performed by a trusted dealer who takes care of generating the threshold public key as well as all `n` secret shares,
 which are then distributed to the `n` participants via secure channels.
@@ -469,11 +470,11 @@ should also read [Section "Internals of ChillDKG"](#internals-of-chilldkg).
 
 ### Use ChillDKG only for FROST
 
-ChillDKG is designed for usage with the FROST Schnorr signature scheme,
+ChillDKG is designed for usage with the FROST signing protocol as specified in [BIP 445](https://github.com/bitcoin/bips/blob/master/bip-0445.md),
 and its security depends on the specifics of FROST.
 We stress that ChillDKG is not a general-purpose DKG protocol,[^no-simulatable-dkg]
 and **must not** be combined with other threshold cryptographic schemes,
-e.g., threshold signature schemes other than FROST, or threshold decryption schemes,
+e.g., FROST specifications other than [BIP 445](https://github.com/bitcoin/bips/blob/master/bip-0445.md), threshold signature schemes other than FROST, or threshold decryption schemes,
 without careful further consideration, which is not in the scope of this document.
 
 [^no-simulatable-dkg]: As a variant of Pedersen DKG, ChillDKG does not provide simulation-based security [GJKR07](https://doi.org/10.1007/s00145-006-0347-3). Roughly speaking, if ChillDKG is combined with some threshold cryptographic scheme, the security of the combination is not automatically implied by the security of the two components. Instead, the security of every combination must be analyzed separately. The security of the specific combination of SimplPedPop (as the core building block of ChillDKG) and FROST has been analyzed [CGRS23](https://eprint.iacr.org/2023/899).
@@ -518,10 +519,9 @@ but even an attacker in full control of communication links will not be able to 
 If a ChillDKG session returns an output to a participant or the coordinator,
 then we say that this party *deems the protocol session successful*.
 In that case, the DKG output is a triple consisting of a *secret share* for participating in FROST signing sessions (individual to each participant, not returned to the coordinator), the *threshold public key* representing the `t`-of-`n` policy of the group (common to all participants and the coordinator), and a list of `n` *public shares* for verification of individual contributions to a FROST signing session (common to all participants and the coordinator).
-Moreover, all parties obtain *recovery data* (common to all participants and the coordinator), whose purpose is detailed in the next subsection.
+See [BIP 445](https://github.com/bitcoin/bips/blob/master/bip-0445.md) for details on signing.
 
-To participate in the FROST signing protocol, signers need their DKG output and their index in the host public key list, although the full list of host public keys is not required for signing.
-Additionally, the set of indices of all participating signers within the host public key list is required to initiate a signing session.
+Moreover, all parties obtain *recovery data* (common to all participants and the coordinator), whose purpose is detailed in the next subsection.
 
 ### Backup and Recovery
 

--- a/README.md
+++ b/README.md
@@ -518,8 +518,10 @@ but even an attacker in full control of communication links will not be able to 
 
 If a ChillDKG session returns an output to a participant or the coordinator,
 then we say that this party *deems the protocol session successful*.
-In that case, the DKG output is a triple consisting of a *secret share* for participating in FROST signing sessions (individual to each participant, not returned to the coordinator), the *threshold public key* representing the `t`-of-`n` policy of the group (common to all participants and the coordinator), and a list of `n` *public shares* for verification of individual contributions to a FROST signing session (common to all participants and the coordinator).
+In that case, the DKG output is a triple consisting of a *secret share* for participating in FROST signing sessions (individual to each participant, not returned to the coordinator), the *threshold public key* representing the `t`-of-`n` policy of the group (common to all participants and the coordinator), and a list of `n` *public shares* for verification of individual contributions to a FROST signing session (common to all participants and the coordinator).[^index-position-mapping]
 See [BIP 445](https://github.com/bitcoin/bips/blob/master/bip-0445.md) for details on signing.
+
+[^index-position-mapping]: The secret sharing is as expected by [BIP 445](https://github.com/bitcoin/bips/blob/master/bip-0445.md), i.e., there exists a scalar polynomial `f` of degree `t-1` such that `f(0)` is the discrete logarithm of the threshold public key and every participant `i` has secret share `f(i + 1)`.
 
 Moreover, all parties obtain *recovery data* (common to all participants and the coordinator), whose purpose is detailed in the next subsection.
 


### PR DESCRIPTION
I wanted to provide an alternative to #111 but then I noticed that the hostpubkeys are not even mentioned in the "Usage" section, which is supposed to be understandable without the "Internals" section. 

So this ended up in a larger rewrite that now also incudes the freshly assigned BIP number of the signing BIP.