### PR TITLE
text: Require authenticity of pubkeys before session

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,9 +494,8 @@ and thus the list assigns each participant a unique index in the range of `0` to
 The list of host public keys and the signing threshold `t` together
 form the public *session parameters*, the common input to all participants and the coordinator.
 
-ChillDKG requires that all participants have authentic copies of all other participants' host public keys.[^trust-anchor]
+Each participant **must** ensure to have authentic copies of all other participants' host public keys before the start of the session.[^trust-anchor]
 Authenticity of the host public keys can be verified through pairwise out-of-band comparisons between every pair of participants.
-This verification can occur at any time before the DKG session is finalized, in particular before the start of the session.
 
 [^trust-anchor]: No protocol can prevent man-in-the-middle attacks without this or a comparable assumption.
 Note that this requirement is implicit in other schemes as well.
@@ -761,18 +760,17 @@ A `SessionParams` tuple holds the common parameters of a DKG session.
   This is the number of participants that will be required to sign.
   It must hold that `1 <= t <= len(hostpubkeys) <= 2**32 - 1`.
 
-  Participants **must** ensure that they have obtained authentic host
-  public keys of all the other participants in the session to make
-  sure that they run the DKG and generate a threshold public key with
-  the intended set of participants. This is analogous to traditional
-  threshold signatures (known as "multisig" in the Bitcoin community),
-  [[BIP 383](https://github.com/bitcoin/bips/blob/master/bip-0383.mediawiki)],
-  where the participants need to obtain authentic extended public keys
-  ("xpubs") from the other participants to generate multisig
-  addresses, or MuSig2
-  [[BIP 327](https://github.com/bitcoin/bips/blob/master/bip-0327.mediawiki)],
-  where the participants need to obtain authentic individual public
-  keys of the other participants to generate an aggregated public key.
+  Each participant **must** ensure to have authentic copies of all other
+  participants' host public keys before the start of the session, e.g., by
+  confirming authenticity of each host public key with the expected key
+  holder out of band. This is analogous to traditional threshold signatures
+  (known as "multisig" in the Bitcoin community), [[BIP
+  383](https://github.com/bitcoin/bips/blob/master/bip-0383.mediawiki)], where
+  a signer needs the other signers' authentic extended public keys ("xpubs")
+  to generate multisig addresses, or MuSig2 [[BIP
+  327](https://github.com/bitcoin/bips/blob/master/bip-0327.mediawiki)], where
+  a signer needs the other participants' authentic individual public keys to
+  generate an aggregated public key.
 
   A DKG session will fail if the participants and the coordinator in a session
   don't have the `hostpubkeys` in the same order. This will make sure that

--- a/python/chilldkg_ref/chilldkg.py
+++ b/python/chilldkg_ref/chilldkg.py
@@ -215,18 +215,17 @@ class SessionParams(NamedTuple):
             This is the number of participants that will be required to sign.
             It must hold that `1 <= t <= len(hostpubkeys) <= 2**32 - 1`.
 
-    Participants **must** ensure that they have obtained authentic host
-    public keys of all the other participants in the session to make
-    sure that they run the DKG and generate a threshold public key with
-    the intended set of participants. This is analogous to traditional
-    threshold signatures (known as "multisig" in the Bitcoin community),
-    [[BIP 383](https://github.com/bitcoin/bips/blob/master/bip-0383.mediawiki)],
-    where the participants need to obtain authentic extended public keys
-    ("xpubs") from the other participants to generate multisig
-    addresses, or MuSig2
-    [[BIP 327](https://github.com/bitcoin/bips/blob/master/bip-0327.mediawiki)],
-    where the participants need to obtain authentic individual public
-    keys of the other participants to generate an aggregated public key.
+    Each participant **must** ensure to have authentic copies of all other
+    participants' host public keys before the start of the session, e.g., by
+    confirming authenticity of each host public key with the expected key
+    holder out of band. This is analogous to traditional threshold signatures
+    (known as "multisig" in the Bitcoin community), [[BIP
+    383](https://github.com/bitcoin/bips/blob/master/bip-0383.mediawiki)], where
+    a signer needs the other signers' authentic extended public keys ("xpubs")
+    to generate multisig addresses, or MuSig2 [[BIP
+    327](https://github.com/bitcoin/bips/blob/master/bip-0327.mediawiki)], where
+    a signer needs the other participants' authentic individual public keys to
+    generate an aggregated public key.
 
     A DKG session will fail if the participants and the coordinator in a session
     don't have the `hostpubkeys` in the same order. This will make sure that


### PR DESCRIPTION
This is subtle. In principle, checking authenticity could be done at any point in time as long as it happens before sending out signatures in step2: if it's postponed to after step2 and fails for some participant, then someone may have sent money to the threshold pubkey but this participant has aborted and won't participate in signing session. This is a situation we want to avoid.

In other words, if a participant sends a signature, this is also meant as a statement that this participant has completed the protocol *entirely* and is ready to sign according to the rules of the application, which includes that authenticity has been checked.

So in principle, we could allow that checking authenticity happens during the protocol, i.e., after the start of step1 but before the start of step2. But that's not very useful in practice: if the check is manual (e.g., out-of-band eyeballing), then it will anyway take much longer than a protocol step; if it's automatic (e.g., a DB lookup), then there's no reason not to perform it before the protocol.

As a conclusion, it's much simpler to require that checking authenticity happens before the start of the session. This is also defense in depth: if public keys are checked before the start of the session, then we never encrypt secret shares to the attacker. Encrypting to the attacker should not be a problem if we abort later, but not doing it in the first place sounds like a good idea.