### PR TITLE
Rename params_id to params_hash and mention in text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1489,6 +1489,8 @@ The `PATCH` version is incremented for other noteworthy changes (bug fixes, test
   * Remove message classes from the public API; protocol messages are passed as `bytes`.
   * Remove `ParticipantMsgParseError` and `CoordinatorMsgParseError` from the public API.
   * Add `RandomnessError`, `InvalidRecoveryAckError`, and `FaultyParticipantError` to the public API.
+  * Align terminology and naming with the draft of [BIP 445](bip-0445.md), including renaming participant "index" to "identifier".
+  * Rename `params_id` to `params_hash` to avoid confusion with the participant identifier and update the hash tag accordingly.
   * Rename `secp256k1proto` to `secp256k1lab` and separate it as an independent subtree for reuse across projects; see the [upstream repository](https://github.com/secp256k1lab/secp256k1lab).
   * Update the preamble per BIP 3.
 * *0.2.0* (2024-12-19): In addition to various readability improvements to specification and reference implementation, the following major changes were implemented:

--- a/README.md
+++ b/README.md
@@ -787,29 +787,29 @@ A `SessionParams` tuple holds the common parameters of a DKG session.
   keys with the [KeySort algorithm specified in
   BIP 327](bip-0327.mediawiki#key-sorting) to abstract away from the order.
 
-#### params\_id
+#### params\_hash
 
 ```python
-def params_id(params: SessionParams) -> bytes
+def params_hash(params: SessionParams) -> bytes
 ```
 
-Return the parameters ID, a unique representation of the `SessionParams`.
+Return a hash of the session parameters for out-of-band comparison.
 
 In the common scenario that the participants obtain host public keys from
 the other participants over channels that do not provide end-to-end
 authentication of the sending participant (e.g., if the participants simply
 send their unauthenticated host public keys to the coordinator, who is
-supposed to relay them to all participants), the parameters ID serves as a
+supposed to relay them to all participants), the parameters hash serves as a
 convenient way to perform an out-of-band comparison of all host public keys.
-It is a collision-resistant cryptographic hash of the `SessionParams`
-tuple. As a result, if all participants have obtained an identical
-parameters ID (as can be verified out-of-band), then they all agree on all
-host public keys and the threshold `t`, and in particular, all participants
-have obtained authentic public host keys.
+It is a collision-resistant cryptographic hash of the `SessionParams` tuple.
+As a result, if all participants have obtained an identical parameters hash
+(as can be verified out-of-band), then they all agree on all host public
+keys and the threshold `t`, and in particular, all participants have
+obtained authentic public host keys.
 
 *Returns*:
 
-- `bytes` - The parameters ID, a 32-byte string.
+- `bytes` - The parameters hash, a 32-byte string.
 
 
 *Raises*:

--- a/README.md
+++ b/README.md
@@ -499,7 +499,8 @@ The list of host public keys and the signing threshold `t` together
 form the public *session parameters*, the common input to all participants and the coordinator.
 
 Each participant **must** ensure to have authentic copies of all other participants' host public keys before the start of the session.[^trust-anchor]
-Authenticity of the host public keys can be verified through pairwise out-of-band comparisons between every pair of participants.
+A participant can verify authenticity by comparing every other host public key with the corresponding participant out-of-band,
+or more conveniently, by comparing a short *parameters hash* (a hash of the session parameters) with every other participant out-of-band.
 
 [^trust-anchor]: No protocol can prevent man-in-the-middle attacks without this or a comparable assumption.
 Note that this requirement is implicit in other schemes as well.

--- a/python/chilldkg_ref/chilldkg.py
+++ b/python/chilldkg_ref/chilldkg.py
@@ -38,7 +38,7 @@ from .vss import VSSCommitment
 __all__ = [
     # Functions
     "hostpubkey_gen",
-    "params_id",
+    "params_hash",
     "participant_step1",
     "participant_step2",
     "participant_finalize",
@@ -260,23 +260,23 @@ def params_validate(params: SessionParams) -> None:
         hostpubkey_to_id[hostpubkey] = i
 
 
-def params_id(params: SessionParams) -> bytes:
-    """Return the parameters ID, a unique representation of the `SessionParams`.
+def params_hash(params: SessionParams) -> bytes:
+    """Return a hash of the session parameters for out-of-band comparison.
 
     In the common scenario that the participants obtain host public keys from
     the other participants over channels that do not provide end-to-end
     authentication of the sending participant (e.g., if the participants simply
     send their unauthenticated host public keys to the coordinator, who is
-    supposed to relay them to all participants), the parameters ID serves as a
+    supposed to relay them to all participants), the parameters hash serves as a
     convenient way to perform an out-of-band comparison of all host public keys.
-    It is a collision-resistant cryptographic hash of the `SessionParams`
-    tuple. As a result, if all participants have obtained an identical
-    parameters ID (as can be verified out-of-band), then they all agree on all
-    host public keys and the threshold `t`, and in particular, all participants
-    have obtained authentic public host keys.
+    It is a collision-resistant cryptographic hash of the `SessionParams` tuple.
+    As a result, if all participants have obtained an identical parameters hash
+    (as can be verified out-of-band), then they all agree on all host public
+    keys and the threshold `t`, and in particular, all participants have
+    obtained authentic public host keys.
 
     Returns:
-        bytes: The parameters ID, a 32-byte string.
+        bytes: The parameters hash, a 32-byte string.
 
     Raises:
         InvalidHostPubkeyError: If `hostpubkeys` contains an invalid public key.
@@ -288,12 +288,12 @@ def params_id(params: SessionParams) -> bytes:
     hostpubkeys, t = params
 
     t_bytes = t.to_bytes(4, byteorder="big")
-    params_id = tagged_hash_bip_dkg(
-        "params_id",
+    params_hash = tagged_hash_bip_dkg(
+        "params_hash",
         t_bytes + b"".join(hostpubkeys),
     )
-    assert len(params_id) == 32
-    return params_id
+    assert len(params_hash) == 32
+    return params_hash
 
 
 class SessionParamsError(ValueError):

--- a/python/example.py
+++ b/python/example.py
@@ -20,7 +20,7 @@ from chilldkg_ref.chilldkg import (
     coordinator_investigate,
     coordinator_step1,
     hostpubkey_gen,
-    params_id,
+    params_hash,
     participant_finalize,
     participant_investigate,
     participant_step1,
@@ -265,7 +265,7 @@ def main():
     print("=== Session parameters ===")
     pphex(params)
     print()
-    print(f"Session parameters identifier: {params_id(params).hex()}")
+    print(f"Session parameters hash: {params_hash(params).hex()}")
     print()
 
     try:

--- a/python/gen_vector_utils/session.py
+++ b/python/gen_vector_utils/session.py
@@ -2,7 +2,7 @@ from secp256k1lab.secp256k1 import Scalar
 from secp256k1lab.util import bytes_from_int
 
 from chilldkg_ref import chilldkg
-from chilldkg_ref.chilldkg import hostpubkey_gen, params_id
+from chilldkg_ref.chilldkg import hostpubkey_gen, params_hash
 
 from .fixtures import AUX_RAND_HEX, HOSTSECKEYS_HEX, RANDOMS_HEX
 from .util import (
@@ -89,16 +89,16 @@ def generate_hostpubkey_vectors():
     }
 
 
-def generate_params_id_vectors():
+def generate_params_hash_vectors():
     description = [
-        "Test vectors for params_id(params).",
-        "Computes a unique 32-byte identifier for session parameters (hostpubkeys, threshold).",
+        "Test vectors for params_hash(params).",
+        "Computes a 32-byte hash of the session parameters (hostpubkeys, threshold).",
         "",
         "For each valid test case:",
-        "  Call params_id(params) and verify the result equals expectedParamsId.",
+        "  Call params_hash(params) and verify the result equals expectedParamsHash.",
         "",
         "For each error test case:",
-        "  Call params_id(params) and verify it raises an exception matching expectedError.",
+        "  Call params_hash(params) and verify it raises an exception matching expectedError.",
         "  The expectedError object contains 'type' (the exception class name).",
         "  Some errors include 'participant' (identifier of the offending participant)",
         "  or 'participant1'/'participant2' (indices for duplicate keys).",
@@ -118,10 +118,10 @@ def generate_params_id_vectors():
     for case in cases:
         t = case["t"]
         params = chilldkg.SessionParams(hostpubkeys, t)
-        expected_params_id = params_id(params)
+        expected_params_hash = params_hash(params)
         test_case = {
             "params": params_asdict(params),
-            "expectedParamsId": bytes_to_hex(expected_params_id),
+            "expectedParamsHash": bytes_to_hex(expected_params_hash),
             "comment": case["comment"],
         }
         valid_cases.append(test_case)
@@ -130,7 +130,7 @@ def generate_params_id_vectors():
     t = 0
     invalid_params = chilldkg.SessionParams(hostpubkeys, t)
     error = expect_exception(
-        lambda: params_id(invalid_params), chilldkg.ThresholdOrCountError
+        lambda: params_hash(invalid_params), chilldkg.ThresholdOrCountError
     )
     error_cases.append(
         {
@@ -145,7 +145,7 @@ def generate_params_id_vectors():
     with_invalid = [hostpubkeys[0], invalid_hostpubkey, hostpubkeys[2]]
     invalid_params = chilldkg.SessionParams(with_invalid, t)
     error = expect_exception(
-        lambda: params_id(invalid_params), chilldkg.InvalidHostPubkeyError
+        lambda: params_hash(invalid_params), chilldkg.InvalidHostPubkeyError
     )
     error_cases.append(
         {
@@ -159,7 +159,7 @@ def generate_params_id_vectors():
     with_duplicate = [hostpubkeys[0], hostpubkeys[1], hostpubkeys[2], hostpubkeys[1]]
     duplicate_params = chilldkg.SessionParams(with_duplicate, t)
     error = expect_exception(
-        lambda: params_id(duplicate_params), chilldkg.DuplicateHostPubkeyError
+        lambda: params_hash(duplicate_params), chilldkg.DuplicateHostPubkeyError
     )
     error_cases.append(
         {

--- a/python/gen_vectors.py
+++ b/python/gen_vectors.py
@@ -21,7 +21,7 @@ from gen_vector_utils.participant import (
 )
 from gen_vector_utils.session import (
     generate_hostpubkey_vectors,
-    generate_params_id_vectors,
+    generate_params_hash_vectors,
     generate_recover_vectors,
 )
 
@@ -31,7 +31,7 @@ output_dir.mkdir(parents=True, exist_ok=True)
 util.write_json(
     output_dir / "hostpubkey_gen_vectors.json", generate_hostpubkey_vectors()
 )
-util.write_json(output_dir / "params_id_vectors.json", generate_params_id_vectors())
+util.write_json(output_dir / "params_hash_vectors.json", generate_params_hash_vectors())
 util.write_json(output_dir / "recover_vectors.json", generate_recover_vectors())
 util.write_json(
     output_dir / "participant_step1_vectors.json",

--- a/python/tests.py
+++ b/python/tests.py
@@ -39,7 +39,7 @@ def test_chilldkg_params_validate():
     with_duplicate = [hostpubkeys[0], hostpubkeys[1], hostpubkeys[2], hostpubkeys[1]]
     params_with_duplicate = chilldkg.SessionParams(with_duplicate, 2)
     try:
-        _ = chilldkg.params_id(params_with_duplicate)
+        _ = chilldkg.params_hash(params_with_duplicate)
     except chilldkg.DuplicateHostPubkeyError as e:
         assert {e.participant1, e.participant2} == {1, 3}
     else:
@@ -50,14 +50,14 @@ def test_chilldkg_params_validate():
         [hostpubkeys[1], invalid_hostpubkey, hostpubkeys[2]], 1
     )
     try:
-        _ = chilldkg.params_id(params_with_invalid)
+        _ = chilldkg.params_hash(params_with_invalid)
     except chilldkg.InvalidHostPubkeyError as e:
         assert e.participant == 1
     else:
         assert False, "Expected exception"
 
     try:
-        _ = chilldkg.params_id(
+        _ = chilldkg.params_hash(
             chilldkg.SessionParams(hostpubkeys, len(hostpubkeys) + 1)
         )
     except chilldkg.ThresholdOrCountError:
@@ -66,7 +66,7 @@ def test_chilldkg_params_validate():
         assert False, "Expected exception"
 
     try:
-        _ = chilldkg.params_id(chilldkg.SessionParams(hostpubkeys, -2))
+        _ = chilldkg.params_hash(chilldkg.SessionParams(hostpubkeys, -2))
     except chilldkg.ThresholdOrCountError:
         pass
     else:
@@ -412,8 +412,8 @@ def test_hostpubkey_gen_vectors():
         assert_raises(lambda: chilldkg.hostpubkey_gen(hostseckey), expected_error)
 
 
-def test_params_id_vectors():
-    input_file = VECTORS_DIR / "params_id_vectors.json"
+def test_params_hash_vectors():
+    input_file = VECTORS_DIR / "params_hash_vectors.json"
     with open(input_file) as f:
         test_data = json.load(f)
 
@@ -423,13 +423,13 @@ def test_params_id_vectors():
 
     for test_case in valid_test_cases:
         params = params_from_dict(test_case["params"])
-        expected_id = bytes.fromhex(test_case["expectedParamsId"])
-        assert expected_id == chilldkg.params_id(params)
+        expected_hash = bytes.fromhex(test_case["expectedParamsHash"])
+        assert expected_hash == chilldkg.params_hash(params)
 
     for test_case in error_test_cases:
         params = params_from_dict(test_case["params"])
         expected_error = test_case["expectedError"]
-        assert_raises(lambda: chilldkg.params_id(params), expected_error)
+        assert_raises(lambda: chilldkg.params_hash(params), expected_error)
 
 
 def test_participant_step1_vectors():
@@ -901,7 +901,7 @@ for t, n in [(1, 1), (1, 2), (2, 2), (2, 3), (2, 5)]:
     test_correctness(t, n, simulate_chilldkg, recovery=True, investigation=True)
     test_correctness(t, n, simulate_chilldkg_full, recovery=True)
 test_hostpubkey_gen_vectors()
-test_params_id_vectors()
+test_params_hash_vectors()
 test_participant_step1_vectors()
 test_participant_step2_vectors()
 test_participant_finalize_vectors()

--- a/python/vectors/params_hash_vectors.json
+++ b/python/vectors/params_hash_vectors.json
@@ -1,13 +1,13 @@
 {
     "description": [
-        "Test vectors for params_id(params).",
-        "Computes a unique 32-byte identifier for session parameters (hostpubkeys, threshold).",
+        "Test vectors for params_hash(params).",
+        "Computes a 32-byte hash of the session parameters (hostpubkeys, threshold).",
         "",
         "For each valid test case:",
-        "  Call params_id(params) and verify the result equals expectedParamsId.",
+        "  Call params_hash(params) and verify the result equals expectedParamsHash.",
         "",
         "For each error test case:",
-        "  Call params_id(params) and verify it raises an exception matching expectedError.",
+        "  Call params_hash(params) and verify it raises an exception matching expectedError.",
         "  The expectedError object contains 'type' (the exception class name).",
         "  Some errors include 'participant' (identifier of the offending participant)",
         "  or 'participant1'/'participant2' (indices for duplicate keys)."
@@ -24,7 +24,7 @@
                 ],
                 "t": 2
             },
-            "expectedParamsId": "566F4DA6A6E6875F2FFE99E988310417F6CCA3E5B8F46CB9980AE3D5B2570A2A",
+            "expectedParamsHash": "6A03D4E831DBF10F71C2C47F8F31FA5BCEDBC266B336DEBA7E11607697CEEB7C",
             "comment": "standard 2-of-3 threshold"
         },
         {
@@ -37,7 +37,7 @@
                 ],
                 "t": 1
             },
-            "expectedParamsId": "1FB80306427F73D9C7E904D6B09D49D15B6F4E499D4746D9EA952B28D51B6820",
+            "expectedParamsHash": "3A0AC9644496D6A5723772EC7CF81462095519D107C3D4C6E6B0DD66951FADEB",
             "comment": "min threshold value"
         },
         {
@@ -50,7 +50,7 @@
                 ],
                 "t": 3
             },
-            "expectedParamsId": "D22DDB63254A9A2DC0B33CD6BE7AC1133DE42133CB670FDBF2A35113092E89BA",
+            "expectedParamsHash": "CAE987A3D2B2ACD32FEACE9CEAE231026C03AE26228EA026BCE82A08A5BF77E2",
             "comment": "max threshold value"
         }
     ],


### PR DESCRIPTION
This mitigates the `id` naming thing a bit. `id` still shadows the Python built-in function, but there can't be any confusion with the participant id.