### PR TITLE
python: Rename id to participant_id

### DIFF
--- a/python/chilldkg_ref/chilldkg.py
+++ b/python/chilldkg_ref/chilldkg.py
@@ -78,18 +78,18 @@ __all__ = [
 ###
 
 
-def certeq_message(x: bytes, id: int) -> bytes:
+def certeq_message(x: bytes, participant_id: int) -> bytes:
     # Domain separation as described in BIP 340
     prefix = (BIP_TAG + "certeq message").encode()
     prefix = prefix + b"\x00" * (33 - len(prefix))
     assert len(prefix) == 33
-    return prefix + id.to_bytes(4, "big") + x
+    return prefix + participant_id.to_bytes(4, "big") + x
 
 
 def certeq_participant_step(
-    hostseckey: bytes, id: int, x: bytes, aux_rand: bytes
+    hostseckey: bytes, participant_id: int, x: bytes, aux_rand: bytes
 ) -> bytes:
-    msg = certeq_message(x, id)
+    msg = certeq_message(x, participant_id)
     return schnorr_sign(msg, hostseckey, aux_rand=aux_rand)
 
 
@@ -131,16 +131,18 @@ class InvalidSignatureInCertificateError(ValueError):
 ###
 
 
-def recovery_ack_message(x: bytes, id: int) -> bytes:
+def recovery_ack_message(x: bytes, participant_id: int) -> bytes:
     # Domain separation as described in BIP 340
     prefix = (BIP_TAG + "recovery acknowledgment").encode()
     prefix = prefix + b"\x00" * (33 - len(prefix))
     assert len(prefix) == 33
-    return prefix + id.to_bytes(4, "big") + x
+    return prefix + participant_id.to_bytes(4, "big") + x
 
 
-def recovery_ack_sign(hostseckey: bytes, id: int, x: bytes, aux_rand: bytes) -> bytes:
-    msg = recovery_ack_message(x, id)
+def recovery_ack_sign(
+    hostseckey: bytes, participant_id: int, x: bytes, aux_rand: bytes
+) -> bytes:
+    msg = recovery_ack_message(x, participant_id)
     return schnorr_sign(msg, hostseckey, aux_rand=aux_rand)
 
 
@@ -548,7 +550,7 @@ def deserialize_recovery_data(
 
 class ParticipantState1(NamedTuple):
     params: SessionParams
-    id: int
+    participant_id: int
     enc_state: encpedpop.ParticipantState
 
 
@@ -593,7 +595,7 @@ def participant_step1(
     (hostpubkeys, t) = params
 
     try:
-        id = hostpubkeys.index(hostpubkey)
+        participant_id = hostpubkeys.index(hostpubkey)
     except ValueError as e:
         raise HostSeckeyError(
             "Host secret key does not match any host public key"
@@ -612,11 +614,11 @@ def participant_step1(
         t=t,
         # This requires the joint security of Schnorr signatures and ECDH.
         enckeys=hostpubkeys,
-        id=id,
+        participant_id=participant_id,
         random=random,
     )
 
-    state1 = ParticipantState1(params, id, enc_state)
+    state1 = ParticipantState1(params, participant_id, enc_state)
     pmsg1 = enc_pmsg
     return state1, pmsg1
 
@@ -681,8 +683,8 @@ def participant_step2(
     if len(aux_rand) != 32:
         raise ValueError
 
-    params, id, enc_state = state1
-    if hostpubkey != params.hostpubkeys[id]:
+    params, participant_id, enc_state = state1
+    if hostpubkey != params.hostpubkeys[participant_id]:
         raise HostSeckeyError(
             "Host secret key does not match the one used in participant_step1"
         )
@@ -697,7 +699,7 @@ def participant_step2(
         state=enc_state,
         deckey=hostseckey,
         cmsg=enc_cmsg.to_bytes(),
-        enc_secshare=enc_secshares[id],
+        enc_secshare=enc_secshares[participant_id],
     )
 
     # Include the enc_shares in eq_input to ensure that participants agree on
@@ -705,7 +707,7 @@ def participant_step2(
     eq_input += b"".join([bytes_from_int(int(share)) for share in enc_secshares])
     dkg_output = DKGOutput._make(enc_dkg_output)
     state2 = ParticipantState2(params, eq_input, dkg_output)
-    sig = certeq_participant_step(hostseckey, id, eq_input, aux_rand)
+    sig = certeq_participant_step(hostseckey, participant_id, eq_input, aux_rand)
     pmsg2 = ParticipantMsg2(sig).to_bytes()
     return state2, pmsg2
 
@@ -862,11 +864,11 @@ def coordinator_step1(
         raise ValueError
 
     pmsgs1_parsed = []
-    for id, pmsg1 in enumerate(pmsgs1):
+    for participant_id, pmsg1 in enumerate(pmsgs1):
         try:
             parsed = ParticipantMsg1.from_bytes(pmsg1, t=t, n=len(hostpubkeys))
         except MsgParseError as e:
-            raise FaultyParticipantError(id, *e.args) from e
+            raise FaultyParticipantError(participant_id, *e.args) from e
         pmsgs1_parsed.append(parsed)
 
     enc_cmsg, enc_dkg_output, eq_input, enc_secshares = encpedpop.coordinator_step(
@@ -966,11 +968,11 @@ def coordinator_investigate(pmsgs: list[bytes], params: SessionParams) -> list[b
     n = len(pmsgs)
     t = params.t
     pmsgs_parsed = []
-    for id, pmsg in enumerate(pmsgs):
+    for participant_id, pmsg in enumerate(pmsgs):
         try:
             parsed = ParticipantMsg1.from_bytes(pmsg, t=t, n=n)
         except MsgParseError as e:
-            raise FaultyParticipantError(id, *e.args) from e
+            raise FaultyParticipantError(participant_id, *e.args) from e
         pmsgs_parsed.append(parsed)
     enc_cinvs = encpedpop.coordinator_investigate(
         [pmsg.enc_pmsg.to_bytes() for pmsg in pmsgs_parsed], t
@@ -1040,7 +1042,7 @@ def recover(
     if hostseckey:
         hostpubkey = hostpubkey_gen(hostseckey)  # ValueError or HostSeckeyError
         try:
-            id = hostpubkeys.index(hostpubkey)
+            participant_id = hostpubkeys.index(hostpubkey)
         except ValueError as e:
             raise HostSeckeyError(
                 "Host secret key does not match any host public key in the recovery data"
@@ -1050,17 +1052,19 @@ def recover(
         enc_context = encpedpop.serialize_enc_context(t, hostpubkeys)
         secshare = encpedpop.decrypt_sum(
             hostseckey,
-            hostpubkeys[id],
+            hostpubkeys[participant_id],
             pubnonces,
             enc_context,
-            id,
-            enc_secshares[id],
+            participant_id,
+            enc_secshares[participant_id],
         )
         secshare_tweaked = secshare + tweak
 
         # This is just a sanity check. Our signature is valid, so we have done
         # an equivalent check already during the actual session.
-        assert VSSCommitment.verify_secshare(secshare_tweaked, pubshares[id])
+        assert VSSCommitment.verify_secshare(
+            secshare_tweaked, pubshares[participant_id]
+        )
     else:
         secshare_tweaked = None
 
@@ -1121,7 +1125,7 @@ def participant_recovery_ack_sign(
     (hostpubkeys, t) = params
 
     try:
-        id = hostpubkeys.index(hostpubkey)
+        participant_id = hostpubkeys.index(hostpubkey)
     except ValueError as e:
         raise HostSeckeyError(
             "Host secret key does not match any host public key"
@@ -1139,7 +1143,7 @@ def participant_recovery_ack_sign(
             "Recovery data does not match the provided session parameters"
         )
 
-    sig = recovery_ack_sign(hostseckey, id, recovery_data, aux_rand)
+    sig = recovery_ack_sign(hostseckey, participant_id, recovery_data, aux_rand)
     rmsg = RecoveryAckMsg(sig).to_bytes()
     return rmsg
 

--- a/python/chilldkg_ref/encpedpop.py
+++ b/python/chilldkg_ref/encpedpop.py
@@ -51,7 +51,7 @@ def encaps_multi(
     deckey: bytes,
     enckeys: list[bytes],
     context: bytes,
-    id: int,
+    participant_id: int,
 ) -> list[Scalar]:
     # This is effectively the "Hashed ElGamal" multi-recipient KEM described in
     # Section 5 of "Multi-recipient encryption, revisited" by Alexandre Pinto,
@@ -62,7 +62,7 @@ def encaps_multi(
     pads = []
     for i, enckey in enumerate(enckeys):
         context_ = i.to_bytes(4, byteorder="big") + context
-        if i == id:
+        if i == participant_id:
             # We're encrypting to ourselves, so we use a symmetrically derived
             # pad to save the ECDH computation.
             pad = self_pad(symkey=deckey, nonce=pubnonce, context=context_)
@@ -84,10 +84,10 @@ def encrypt_multi(
     deckey: bytes,
     enckeys: list[bytes],
     context: bytes,
-    id: int,
+    participant_id: int,
     plaintexts: list[Scalar],
 ) -> list[Scalar]:
-    pads = encaps_multi(secnonce, pubnonce, deckey, enckeys, context, id)
+    pads = encaps_multi(secnonce, pubnonce, deckey, enckeys, context, participant_id)
     if len(plaintexts) != len(pads):
         raise ValueError
     ciphertexts = [plaintext + pad for plaintext, pad in zip(plaintexts, pads)]
@@ -99,12 +99,12 @@ def decaps_multi(
     enckey: bytes,
     pubnonces: list[bytes],
     context: bytes,
-    id: int,
+    participant_id: int,
 ) -> list[Scalar]:
-    context_ = id.to_bytes(4, byteorder="big") + context
+    context_ = participant_id.to_bytes(4, byteorder="big") + context
     pads = []
     for sender_id, pubnonce in enumerate(pubnonces):
-        if sender_id == id:
+        if sender_id == participant_id:
             pad = self_pad(symkey=deckey, nonce=pubnonce, context=context_)
         else:
             try:
@@ -130,12 +130,12 @@ def decrypt_sum(
     enckey: bytes,
     pubnonces: list[bytes],
     context: bytes,
-    id: int,
+    participant_id: int,
     sum_ciphertexts: Scalar,
 ) -> Scalar:
-    if id >= len(pubnonces):
+    if participant_id >= len(pubnonces):
         raise IndexError
-    pads = decaps_multi(deckey, enckey, pubnonces, context, id)
+    pads = decaps_multi(deckey, enckey, pubnonces, context, participant_id)
     sum_plaintexts: Scalar = sum_ciphertexts - Scalar.sum(*pads)
     return sum_plaintexts
 
@@ -272,7 +272,7 @@ class ParticipantState(NamedTuple):
     simpl_state: simplpedpop.ParticipantState
     pubnonce: bytes
     enckeys: list[bytes]
-    id: int
+    participant_id: int
 
 
 class ParticipantInvestigationData(NamedTuple):
@@ -290,7 +290,7 @@ def participant_step1(
     deckey: bytes,
     enckeys: list[bytes],
     t: int,
-    id: int,
+    participant_id: int,
     random: bytes,
 ) -> tuple[ParticipantState, bytes]:
     if t >= 2 ** (4 * 8):
@@ -314,17 +314,17 @@ def participant_step1(
     pubnonce = pubkey_gen_plain(secnonce)
 
     simpl_state, simpl_pmsg, shares = simplpedpop.participant_step1(
-        simpl_seed, t, n, id, simpl_aux_rand
+        simpl_seed, t, n, participant_id, simpl_aux_rand
     )
     assert len(shares) == n
 
     enc_shares = encrypt_multi(
-        secnonce, pubnonce, deckey, enckeys, enc_context, id, shares
+        secnonce, pubnonce, deckey, enckeys, enc_context, participant_id, shares
     )
     simpl_pmsg_parsed = simplpedpop.ParticipantMsg.from_bytes(simpl_pmsg, t=t)
 
     pmsg = ParticipantMsg(simpl_pmsg_parsed, pubnonce, enc_shares).to_bytes()
-    state = ParticipantState(simpl_state, pubnonce, enckeys, id)
+    state = ParticipantState(simpl_state, pubnonce, enckeys, participant_id)
     return state, pmsg
 
 
@@ -334,19 +334,21 @@ def participant_step2(
     cmsg: bytes,
     enc_secshare: Scalar,
 ) -> tuple[simplpedpop.DKGOutput, bytes]:
-    simpl_state, pubnonce, enckeys, id = state
+    simpl_state, pubnonce, enckeys, participant_id = state
     try:
         cmsg_parsed = CoordinatorMsg.from_bytes(cmsg, t=simpl_state.t, n=len(enckeys))
     except MsgParseError as e:
         raise FaultyCoordinatorError(*e.args) from e
     simpl_cmsg, pubnonces = cmsg_parsed
 
-    reported_pubnonce = pubnonces[id]
+    reported_pubnonce = pubnonces[participant_id]
     if reported_pubnonce != pubnonce:
         raise FaultyCoordinatorError("Coordinator replied with wrong pubnonce")
 
     enc_context = serialize_enc_context(simpl_state.t, enckeys)
-    pads = decaps_multi(deckey, enckeys[id], pubnonces, enc_context, id)
+    pads = decaps_multi(
+        deckey, enckeys[participant_id], pubnonces, enc_context, participant_id
+    )
     secshare = enc_secshare - Scalar.sum(*pads)
 
     try:

--- a/python/chilldkg_ref/simplpedpop.py
+++ b/python/chilldkg_ref/simplpedpop.py
@@ -34,17 +34,19 @@ Pop = NewType("Pop", bytes)
 POP_MSG_TAG = BIP_TAG + "pop message"
 
 
-def pop_msg(id: int) -> bytes:
-    return id.to_bytes(4, byteorder="big")
+def pop_msg(participant_id: int) -> bytes:
+    return participant_id.to_bytes(4, byteorder="big")
 
 
-def pop_prove(seckey: bytes, id: int, aux_rand: bytes) -> Pop:
-    sig = schnorr_sign(pop_msg(id), seckey, aux_rand=aux_rand, tag_prefix=POP_MSG_TAG)
+def pop_prove(seckey: bytes, participant_id: int, aux_rand: bytes) -> Pop:
+    sig = schnorr_sign(
+        pop_msg(participant_id), seckey, aux_rand=aux_rand, tag_prefix=POP_MSG_TAG
+    )
     return Pop(sig)
 
 
-def pop_verify(pop: Pop, pubkey: bytes, id: int) -> bool:
-    return schnorr_verify(pop_msg(id), pubkey, pop, tag_prefix=POP_MSG_TAG)
+def pop_verify(pop: Pop, pubkey: bytes, participant_id: int) -> bool:
+    return schnorr_verify(pop_msg(participant_id), pubkey, pop, tag_prefix=POP_MSG_TAG)
 
 
 ###
@@ -188,13 +190,13 @@ def assemble_sum_coms(
 class ParticipantState(NamedTuple):
     t: int
     n: int
-    id: int
+    participant_id: int
     com_to_secret: GE
 
 
 class ParticipantInvestigationData(NamedTuple):
     n: int
-    id: int
+    participant_id: int
     secshare: Scalar
     pubshare: GE
 
@@ -205,7 +207,7 @@ class ParticipantInvestigationData(NamedTuple):
 
 
 def participant_step1(
-    seed: bytes, t: int, n: int, id: int, aux_rand: bytes
+    seed: bytes, t: int, n: int, participant_id: int, aux_rand: bytes
 ) -> tuple[
     ParticipantState,
     bytes,
@@ -217,7 +219,7 @@ def participant_step1(
 ]:
     if t > n:
         raise ValueError
-    if id >= n:
+    if participant_id >= n:
         raise IndexError
     if len(seed) != 32:
         raise ValueError
@@ -226,16 +228,16 @@ def participant_step1(
 
     vss = VSS.generate(seed, t)  # OverflowError if t >= 2**32
     partial_secshares_from_me = vss.secshares(n)
-    pop = pop_prove(vss.secret().to_bytes(), id, aux_rand)
+    pop = pop_prove(vss.secret().to_bytes(), participant_id, aux_rand)
 
     com = vss.commit()
     com_to_secret = com.commitment_to_secret()
     msg = ParticipantMsg(com, pop).to_bytes()
-    state = ParticipantState(t, n, id, com_to_secret)
+    state = ParticipantState(t, n, participant_id, com_to_secret)
     return state, msg, partial_secshares_from_me
 
 
-# Helper function to prepare the secshare for participant id's
+# Helper function to prepare the secshare for a participant's
 # participant_step2() by summing the partial_secshares returned by all
 # participants' participant_step1().
 #
@@ -261,20 +263,20 @@ def participant_step2(
     cmsg: bytes,
     secshare: Scalar,
 ) -> tuple[DKGOutput, bytes]:
-    t, n, id, com_to_secret = state
+    t, n, participant_id, com_to_secret = state
     try:
         cmsg_parsed = CoordinatorMsg.from_bytes(cmsg, t=t, n=n)
     except MsgParseError as e:
         raise FaultyCoordinatorError(*e.args) from e
     coms_to_secrets, sum_coms_to_nonconst_terms, pops = cmsg_parsed
 
-    if coms_to_secrets[id] != com_to_secret:
+    if coms_to_secrets[participant_id] != com_to_secret:
         raise FaultyCoordinatorError(
             "Coordinator sent unexpected first group element for local id"
         )
 
     for i in range(n):
-        if i == id:
+        if i == participant_id:
             # No need to check our own pop.
             continue
         if coms_to_secrets[i].infinity:
@@ -295,12 +297,12 @@ def participant_step2(
     # avoids computing the untweaked pubshare in the happy path and thereby
     # moves a group addition to the error path.
     sum_coms_tweaked, tweak, pubtweak = sum_coms.invalid_taproot_commit()
-    pubshare_tweaked = sum_coms_tweaked.pubshare(id)
+    pubshare_tweaked = sum_coms_tweaked.pubshare(participant_id)
     secshare_tweaked = secshare + tweak
     if not VSSCommitment.verify_secshare(secshare_tweaked, pubshare_tweaked):
         pubshare = pubshare_tweaked - pubtweak
         raise UnknownFaultyParticipantOrCoordinatorError(
-            ParticipantInvestigationData(n, id, secshare, pubshare),
+            ParticipantInvestigationData(n, participant_id, secshare, pubshare),
             "Received invalid secshare; consider using "
             "participant_investigate() to determine a faulty party",
         )
@@ -308,7 +310,7 @@ def participant_step2(
     thresh_pk = sum_coms_tweaked.commitment_to_secret()
     pubshares = [
         sum_coms_tweaked.pubshare(i)
-        if i != id
+        if i != participant_id
         else pubshare_tweaked  # We have computed our own pubshare already.
         for i in range(n)
     ]
@@ -326,7 +328,7 @@ def participant_investigate(
     cinv: bytes,
     partial_secshares: list[Scalar],
 ) -> NoReturn:
-    n, id, secshare, pubshare = error.inv_data
+    n, participant_id, secshare, pubshare = error.inv_data
     if len(partial_secshares) != n:
         raise ValueError
 
@@ -346,7 +348,7 @@ def participant_investigate(
         if not VSSCommitment.verify_secshare(
             partial_secshares[i], partial_pubshares[i]
         ):
-            if i != id:
+            if i != participant_id:
                 raise FaultyParticipantOrCoordinatorError(
                     i, "Participant sent invalid partial secshare"
                 )

--- a/python/example.py
+++ b/python/example.py
@@ -177,7 +177,10 @@ async def coordinator(
 # This is a dummy participant used to demonstrate the investigation procedure.
 # It picks a random victim participant and sends an invalid share to it.
 async def faulty_participant(
-    chan: ParticipantChannel, hostseckey: bytes, params: SessionParams, id: int
+    chan: ParticipantChannel,
+    hostseckey: bytes,
+    params: SessionParams,
+    participant_id: int,
 ):
     n = len(params.hostpubkeys)
     random = random_bytes(32)
@@ -186,7 +189,7 @@ async def faulty_participant(
 
     assert len(pmsg1_parsed.enc_pmsg.enc_shares) == n
     # Pick random victim that is not this participant
-    victim = (id + randint(1, n - 1)) % n
+    victim = (participant_id + randint(1, n - 1)) % n
     pmsg1_parsed.enc_pmsg.enc_shares[victim] += 17
 
     chan.send(pmsg1_parsed.to_bytes())


### PR DESCRIPTION
Follow-up to the naming discussion in #152: rename bare `id` to `participant_id` to stop shadowing the Python built-in.