### PR TITLE
gen_vector_utils: Use qualified imports everywhere

### DIFF
--- a/python/gen_vector_utils/coordinator.py
+++ b/python/gen_vector_utils/coordinator.py
@@ -1,13 +1,6 @@
 import copy
 
 from chilldkg_ref import chilldkg
-from chilldkg_ref.chilldkg import (
-    coordinator_finalize,
-    coordinator_investigate,
-    coordinator_step1,
-    participant_step1,
-    participant_step2,
-)
 
 from .fixtures import AUX_RAND_HEX, HOSTSECKEYS_HEX, RANDOMS_HEX, THRESHOLD_CONFIGS
 from .util import (
@@ -50,7 +43,7 @@ def generate_coordinator_step1_group(t, n):
     for i in range(len(hostpubkeys)):
         _, msg = chilldkg.participant_step1(hostseckeys[i], params, randoms[i])
         pmsgs1.append(msg)
-    _, expected_cmsg1 = coordinator_step1(pmsgs1, params)
+    _, expected_cmsg1 = chilldkg.coordinator_step1(pmsgs1, params)
 
     pmsg1_pool = []
 
@@ -74,7 +67,7 @@ def generate_coordinator_step1_group(t, n):
     # --- Error test case: Invalid threshold ---
     invalid_params = chilldkg.SessionParams(hostpubkeys, 0)
     error = expect_exception(
-        lambda: coordinator_step1(pmsgs1, invalid_params),
+        lambda: chilldkg.coordinator_step1(pmsgs1, invalid_params),
         chilldkg.ThresholdOrCountError,
     )
     error_cases.append(
@@ -89,7 +82,7 @@ def generate_coordinator_step1_group(t, n):
     # --- Error test case: t > n ---
     invalid_params = chilldkg.SessionParams(hostpubkeys, n + 1)
     error = expect_exception(
-        lambda: coordinator_step1(pmsgs1, invalid_params),
+        lambda: chilldkg.coordinator_step1(pmsgs1, invalid_params),
         chilldkg.ThresholdOrCountError,
     )
     error_cases.append(
@@ -106,7 +99,7 @@ def generate_coordinator_step1_group(t, n):
     with_invalid = hostpubkeys[:-1] + [invalid_hostpubkey]
     invalid_params = chilldkg.SessionParams(with_invalid, t)
     error = expect_exception(
-        lambda: coordinator_step1(pmsgs1, invalid_params),
+        lambda: chilldkg.coordinator_step1(pmsgs1, invalid_params),
         chilldkg.InvalidHostPubkeyError,
     )
     error_cases.append(
@@ -122,7 +115,7 @@ def generate_coordinator_step1_group(t, n):
     with_duplicate = hostpubkeys[:-1] + [hostpubkeys[0]]
     duplicate_params = chilldkg.SessionParams(with_duplicate, t)
     error = expect_exception(
-        lambda: coordinator_step1(pmsgs1, duplicate_params),
+        lambda: chilldkg.coordinator_step1(pmsgs1, duplicate_params),
         chilldkg.DuplicateHostPubkeyError,
     )
     error_cases.append(
@@ -139,7 +132,7 @@ def generate_coordinator_step1_group(t, n):
     with_infinity = hostpubkeys[:-1] + [infinity_hostpubkey]
     invalid_params = chilldkg.SessionParams(with_infinity, t)
     error = expect_exception(
-        lambda: coordinator_step1(pmsgs1, invalid_params),
+        lambda: chilldkg.coordinator_step1(pmsgs1, invalid_params),
         chilldkg.InvalidHostPubkeyError,
     )
     error_cases.append(
@@ -154,7 +147,7 @@ def generate_coordinator_step1_group(t, n):
     # --- Error test case: invalid pmsgs1 (n-1 entries instead of n) ---
     short_pmsgs1 = pmsgs1[: n - 1]
     error = expect_exception(
-        lambda: coordinator_step1(short_pmsgs1, params),
+        lambda: chilldkg.coordinator_step1(short_pmsgs1, params),
         ValueError,
     )
     error_cases.append(
@@ -169,7 +162,7 @@ def generate_coordinator_step1_group(t, n):
     # --- Error test case: invalid pmsgs1 (n+1 entries instead of n) ---
     long_pmsgs1 = pmsgs1 + [pmsgs1[0]]  # Add an extra entry
     error = expect_exception(
-        lambda: coordinator_step1(long_pmsgs1, params),
+        lambda: chilldkg.coordinator_step1(long_pmsgs1, params),
         ValueError,
     )
     error_cases.append(
@@ -190,7 +183,7 @@ def generate_coordinator_step1_group(t, n):
     invalid_pmsgs1[1] = invalid_pmsg1_parsed.to_bytes()
 
     error = expect_exception(
-        lambda: coordinator_step1(invalid_pmsgs1, params),
+        lambda: chilldkg.coordinator_step1(invalid_pmsgs1, params),
         ValueError,
     )
     pmsg1_pool.append(bytes_to_hex(invalid_pmsgs1[1]))  # index n
@@ -210,7 +203,7 @@ def generate_coordinator_step1_group(t, n):
     pmsg1_pool.append(bytes_to_hex(empty_pmsgs1))  # index n + 1
     invalid_pmsgs1 = [empty_pmsgs1] + pmsgs1[1:]
     error = expect_exception(
-        lambda: coordinator_step1(invalid_pmsgs1, params),
+        lambda: chilldkg.coordinator_step1(invalid_pmsgs1, params),
         ValueError,
     )
     error_cases.append(
@@ -231,7 +224,7 @@ def generate_coordinator_step1_group(t, n):
     invalid_pmsgs1 = list(pmsgs1)
     invalid_pmsgs1[1] = truncated_pmsg1
     error = expect_exception(
-        lambda: coordinator_step1(invalid_pmsgs1, params),
+        lambda: chilldkg.coordinator_step1(invalid_pmsgs1, params),
         ValueError,
     )
     error_cases.append(
@@ -293,7 +286,7 @@ def generate_coordinator_finalize_group(t, n):
     pstates1 = []
     pmsgs1 = []
     for i in range(len(hostpubkeys)):
-        state, msg = participant_step1(hostseckeys[i], params, randoms[i])
+        state, msg = chilldkg.participant_step1(hostseckeys[i], params, randoms[i])
         pstates1.append(state)
         pmsgs1.append(msg)
     cstate, cmsg1 = chilldkg.coordinator_step1(pmsgs1, params)
@@ -301,9 +294,11 @@ def generate_coordinator_finalize_group(t, n):
     # build pmsgs2 pool with valid messages at indices [0, 1, ..., n - 1]
     pmsgs2 = []
     for i in range(len(hostpubkeys)):
-        _, msg = participant_step2(hostseckeys[i], pstates1[i], cmsg1, aux_rand)
+        _, msg = chilldkg.participant_step2(
+            hostseckeys[i], pstates1[i], cmsg1, aux_rand
+        )
         pmsgs2.append(msg)
-    cmsg2, cout, crec = coordinator_finalize(cstate, pmsgs2)
+    cmsg2, cout, crec = chilldkg.coordinator_finalize(cstate, pmsgs2)
     pmsg2_pool = [bytes_to_hex(m) for m in pmsgs2]
 
     valid_cases = []
@@ -328,7 +323,7 @@ def generate_coordinator_finalize_group(t, n):
         :63
     ]  # truncate sig to 63 bytes
     error_case = expect_exception(
-        lambda: coordinator_finalize(cstate, invalid_pmsgs2_short_sig),
+        lambda: chilldkg.coordinator_finalize(cstate, invalid_pmsgs2_short_sig),
         ValueError,
     )
     pmsg2_pool.append(bytes_to_hex(invalid_pmsgs2_short_sig[1]))  # index n
@@ -346,7 +341,7 @@ def generate_coordinator_finalize_group(t, n):
     invalid_pmsgs2_short = copy.deepcopy(pmsgs2)
     invalid_pmsgs2_short.pop()
     error_case = expect_exception(
-        lambda: coordinator_finalize(cstate, invalid_pmsgs2_short), ValueError
+        lambda: chilldkg.coordinator_finalize(cstate, invalid_pmsgs2_short), ValueError
     )
     error_cases.append(
         {
@@ -359,7 +354,7 @@ def generate_coordinator_finalize_group(t, n):
     # --- Error test case: invalid pmsgs2 (n+1 entries instead of n) ---
     invalid_pmsgs2_long = pmsgs2 + [pmsgs2[0]]
     error_case = expect_exception(
-        lambda: coordinator_finalize(cstate, invalid_pmsgs2_long), ValueError
+        lambda: chilldkg.coordinator_finalize(cstate, invalid_pmsgs2_long), ValueError
     )
     error_cases.append(
         {
@@ -375,7 +370,7 @@ def generate_coordinator_finalize_group(t, n):
         "09C289578B96E6283AB13E4741FB489FC147FB1A5F446A314BA73C052131EFB04B83247A0BCEDF5205202AD64188B24B0BC5B51A17AEB218BD98DBE000C843B9"
     )  # random sig
     error_case = expect_faulty_exception(
-        lambda: coordinator_finalize(cstate, invalid_pmsgs2_sig),
+        lambda: chilldkg.coordinator_finalize(cstate, invalid_pmsgs2_sig),
         chilldkg.FaultyParticipantError,
         1,
     )
@@ -434,7 +429,7 @@ def generate_coordinator_investigate_group(t, n):
     for i in range(len(hostpubkeys)):
         _, msg = chilldkg.participant_step1(hostseckeys[i], params, randoms[i])
         pmsgs1.append(msg)
-    cinv_msgs = coordinator_investigate(pmsgs1, params)
+    cinv_msgs = chilldkg.coordinator_investigate(pmsgs1, params)
 
     # --- Valid test case ---
     valid_cases = [

--- a/python/gen_vector_utils/participant.py
+++ b/python/gen_vector_utils/participant.py
@@ -4,12 +4,6 @@ from secp256k1lab.secp256k1 import GE, Scalar
 from secp256k1lab.util import bytes_from_int
 
 from chilldkg_ref import chilldkg
-from chilldkg_ref.chilldkg import (
-    participant_finalize,
-    participant_investigate,
-    participant_step1,
-    participant_step2,
-)
 
 from .fixtures import AUX_RAND_HEX, HOSTSECKEYS_HEX, RANDOMS_HEX, THRESHOLD_CONFIGS
 from .util import (
@@ -66,7 +60,7 @@ def generate_participant_step1_group(t, n):
     short_hostseckey = bytes.fromhex("631C047D50A67E45E27ED1FF25FCE179")
     assert len(short_hostseckey) == 16
     error = expect_exception(
-        lambda: participant_step1(short_hostseckey, params, random),
+        lambda: chilldkg.participant_step1(short_hostseckey, params, random),
         ValueError,
     )
     error_cases.append(
@@ -81,7 +75,7 @@ def generate_participant_step1_group(t, n):
     # --- Error test case: zero hostseckey ---
     zero_hostseckey = b"\x00" * 32
     error = expect_exception(
-        lambda: participant_step1(zero_hostseckey, params, random),
+        lambda: chilldkg.participant_step1(zero_hostseckey, params, random),
         chilldkg.HostSeckeyError,
     )
     error_cases.append(
@@ -96,7 +90,7 @@ def generate_participant_step1_group(t, n):
     # --- Error test case: Out-of-range hostseckey ---
     invalid_hostseckey = bytes_from_int(Scalar.SIZE)
     error = expect_exception(
-        lambda: participant_step1(invalid_hostseckey, params, random),
+        lambda: chilldkg.participant_step1(invalid_hostseckey, params, random),
         chilldkg.HostSeckeyError,
     )
     error_cases.append(
@@ -111,7 +105,7 @@ def generate_participant_step1_group(t, n):
     # --- Error test case: Invalid threshold ---
     invalid_params = chilldkg.SessionParams(hostpubkeys, 0)
     error = expect_exception(
-        lambda: participant_step1(hostseckeys[0], invalid_params, random),
+        lambda: chilldkg.participant_step1(hostseckeys[0], invalid_params, random),
         chilldkg.ThresholdOrCountError,
     )
     error_cases.append(
@@ -126,7 +120,7 @@ def generate_participant_step1_group(t, n):
     # --- Error test case: t > n ---
     invalid_params = chilldkg.SessionParams(hostpubkeys, n + 1)
     error = expect_exception(
-        lambda: participant_step1(hostseckeys[0], invalid_params, random),
+        lambda: chilldkg.participant_step1(hostseckeys[0], invalid_params, random),
         chilldkg.ThresholdOrCountError,
     )
     error_cases.append(
@@ -143,7 +137,7 @@ def generate_participant_step1_group(t, n):
     with_invalid = hostpubkeys[:-1] + [invalid_hostpubkey]
     invalid_params = chilldkg.SessionParams(with_invalid, t)
     error = expect_exception(
-        lambda: participant_step1(hostseckeys[0], invalid_params, random),
+        lambda: chilldkg.participant_step1(hostseckeys[0], invalid_params, random),
         chilldkg.InvalidHostPubkeyError,
     )
     error_cases.append(
@@ -160,7 +154,7 @@ def generate_participant_step1_group(t, n):
     with_invalid = hostpubkeys[:-1] + [invalid_hostpubkey]
     invalid_params = chilldkg.SessionParams(with_invalid, t)
     error = expect_exception(
-        lambda: participant_step1(hostseckeys[0], invalid_params, random),
+        lambda: chilldkg.participant_step1(hostseckeys[0], invalid_params, random),
         chilldkg.InvalidHostPubkeyError,
     )
     error_cases.append(
@@ -177,7 +171,7 @@ def generate_participant_step1_group(t, n):
     with_infinity = hostpubkeys[:-1] + [infinity_hostpubkey]
     invalid_params = chilldkg.SessionParams(with_infinity, t)
     error = expect_exception(
-        lambda: participant_step1(hostseckeys[0], invalid_params, random),
+        lambda: chilldkg.participant_step1(hostseckeys[0], invalid_params, random),
         chilldkg.InvalidHostPubkeyError,
     )
     error_cases.append(
@@ -193,7 +187,7 @@ def generate_participant_step1_group(t, n):
     with_duplicate = hostpubkeys[:-1] + [hostpubkeys[0]]
     duplicate_params = chilldkg.SessionParams(with_duplicate, t)
     error = expect_exception(
-        lambda: participant_step1(hostseckeys[0], duplicate_params, random),
+        lambda: chilldkg.participant_step1(hostseckeys[0], duplicate_params, random),
         chilldkg.DuplicateHostPubkeyError,
     )
     error_cases.append(
@@ -210,7 +204,7 @@ def generate_participant_step1_group(t, n):
         "759DE9306FB02B3D84C455112BF1F3360401DC383ECD1FCEDE59EC809D6F9FE7"
     )
     error = expect_exception(
-        lambda: participant_step1(rand_hostseckey, params, random),
+        lambda: chilldkg.participant_step1(rand_hostseckey, params, random),
         chilldkg.HostSeckeyError,
     )
     error_cases.append(
@@ -226,7 +220,7 @@ def generate_participant_step1_group(t, n):
     short_random = bytes.fromhex("42B53D62E27380D6F7096EDA1C28C57D")  # 16 bytes
     assert len(short_random) == 16
     error = expect_exception(
-        lambda: participant_step1(hostseckeys[0], params, short_random),
+        lambda: chilldkg.participant_step1(hostseckeys[0], params, short_random),
         ValueError,
     )
     error_cases.append(
@@ -241,7 +235,7 @@ def generate_participant_step1_group(t, n):
     # --- Error test case: Zero randomness ---
     zero_random = b"\x00" * 32
     error = expect_exception(
-        lambda: participant_step1(hostseckeys[0], params, zero_random),
+        lambda: chilldkg.participant_step1(hostseckeys[0], params, zero_random),
         chilldkg.RandomnessError,
     )
     error_cases.append(
@@ -304,14 +298,14 @@ def generate_participant_step2_group(t, n):
     pstates1 = []
     pmsgs1 = []
     for i in range(len(hostpubkeys)):
-        state, msg = participant_step1(hostseckeys[i], params, randoms[i])
+        state, msg = chilldkg.participant_step1(hostseckeys[i], params, randoms[i])
         pstates1.append(state)
         pmsgs1.append(msg)
     _, cmsg1 = chilldkg.coordinator_step1(pmsgs1, params)
     aux_rand = bytes.fromhex(AUX_RAND_HEX)
 
     # --- Valid test case ---
-    _, pmsg2 = participant_step2(hostseckeys[0], pstates1[0], cmsg1, aux_rand)
+    _, pmsg2 = chilldkg.participant_step2(hostseckeys[0], pstates1[0], cmsg1, aux_rand)
     valid_cases.append(
         {
             "cmsg1": bytes_to_hex(cmsg1),
@@ -326,7 +320,9 @@ def generate_participant_step2_group(t, n):
     # --- Error test case: Wrong aux randomness length ---
     short_aux_rand = bytes.fromhex("42B53D62E27380D6F7096EDA1C28C57D")
     error = expect_exception(
-        lambda: participant_step2(hostseckeys[0], pstates1[0], cmsg1, short_aux_rand),
+        lambda: chilldkg.participant_step2(
+            hostseckeys[0], pstates1[0], cmsg1, short_aux_rand
+        ),
         ValueError,
     )
     error_cases.append(
@@ -340,7 +336,9 @@ def generate_participant_step2_group(t, n):
     # --- Error test case: hostseckey does not match the one in state1 ---
     mismatched_hostseckey = hostseckeys[1]
     error = expect_exception(
-        lambda: participant_step2(mismatched_hostseckey, pstates1[0], cmsg1, aux_rand),
+        lambda: chilldkg.participant_step2(
+            mismatched_hostseckey, pstates1[0], cmsg1, aux_rand
+        ),
         chilldkg.HostSeckeyError,
     )
     error_cases.append(
@@ -356,7 +354,9 @@ def generate_participant_step2_group(t, n):
     invalid_cmsg1_parsed.enc_cmsg.pubnonces[0] = b"\xeb" * 33  # invalid prefix
     invalid_cmsg1 = invalid_cmsg1_parsed.to_bytes()
     error = expect_exception(
-        lambda: participant_step2(hostseckeys[0], pstates1[0], invalid_cmsg1, aux_rand),
+        lambda: chilldkg.participant_step2(
+            hostseckeys[0], pstates1[0], invalid_cmsg1, aux_rand
+        ),
         chilldkg.FaultyCoordinatorError,
     )
     error_cases.append(
@@ -371,7 +371,9 @@ def generate_participant_step2_group(t, n):
     invalid_cmsg1_parsed.enc_cmsg.pubnonces[1] = b"\xeb" * 33  # invalid prefix
     invalid_cmsg1 = invalid_cmsg1_parsed.to_bytes()
     error = expect_faulty_exception(
-        lambda: participant_step2(hostseckeys[0], pstates1[0], invalid_cmsg1, aux_rand),
+        lambda: chilldkg.participant_step2(
+            hostseckeys[0], pstates1[0], invalid_cmsg1, aux_rand
+        ),
         chilldkg.FaultyParticipantOrCoordinatorError,
         1,
     )
@@ -389,7 +391,9 @@ def generate_participant_step2_group(t, n):
     )  # Invalid x-coordinate
     invalid_cmsg1 = invalid_cmsg1_parsed.to_bytes()
     error = expect_exception(
-        lambda: participant_step2(hostseckeys[0], pstates1[0], invalid_cmsg1, aux_rand),
+        lambda: chilldkg.participant_step2(
+            hostseckeys[0], pstates1[0], invalid_cmsg1, aux_rand
+        ),
         chilldkg.FaultyCoordinatorError,
     )
     error_cases.append(
@@ -406,7 +410,9 @@ def generate_participant_step2_group(t, n):
     )  # Invalid x-coordinate
     invalid_cmsg1 = invalid_cmsg1_parsed.to_bytes()
     error = expect_faulty_exception(
-        lambda: participant_step2(hostseckeys[0], pstates1[0], invalid_cmsg1, aux_rand),
+        lambda: chilldkg.participant_step2(
+            hostseckeys[0], pstates1[0], invalid_cmsg1, aux_rand
+        ),
         chilldkg.FaultyParticipantOrCoordinatorError,
         1,
     )
@@ -424,7 +430,9 @@ def generate_participant_step2_group(t, n):
     ).to_bytes_compressed()
     invalid_cmsg1 = invalid_cmsg1_parsed.to_bytes()
     error = expect_exception(
-        lambda: participant_step2(hostseckeys[0], pstates1[0], invalid_cmsg1, aux_rand),
+        lambda: chilldkg.participant_step2(
+            hostseckeys[0], pstates1[0], invalid_cmsg1, aux_rand
+        ),
         chilldkg.FaultyCoordinatorError,
     )
     error_cases.append(
@@ -441,7 +449,9 @@ def generate_participant_step2_group(t, n):
     ).to_bytes_compressed()
     invalid_cmsg1 = invalid_cmsg1_parsed.to_bytes()
     error = expect_exception(
-        lambda: participant_step2(hostseckeys[0], pstates1[0], invalid_cmsg1, aux_rand),
+        lambda: chilldkg.participant_step2(
+            hostseckeys[0], pstates1[0], invalid_cmsg1, aux_rand
+        ),
         chilldkg.UnknownFaultyParticipantOrCoordinatorError,
     )
     error_cases.append(
@@ -456,7 +466,9 @@ def generate_participant_step2_group(t, n):
     invalid_cmsg1_parsed.enc_cmsg.pubnonces[0] = b"\x00" * 33  # infinity
     invalid_cmsg1 = invalid_cmsg1_parsed.to_bytes()
     error = expect_exception(
-        lambda: participant_step2(hostseckeys[0], pstates1[0], invalid_cmsg1, aux_rand),
+        lambda: chilldkg.participant_step2(
+            hostseckeys[0], pstates1[0], invalid_cmsg1, aux_rand
+        ),
         chilldkg.FaultyCoordinatorError,
     )
     error_cases.append(
@@ -471,7 +483,9 @@ def generate_participant_step2_group(t, n):
     invalid_cmsg1_parsed.enc_cmsg.pubnonces[1] = b"\x00" * 33  # infinity
     invalid_cmsg1 = invalid_cmsg1_parsed.to_bytes()
     error = expect_faulty_exception(
-        lambda: participant_step2(hostseckeys[0], pstates1[0], invalid_cmsg1, aux_rand),
+        lambda: chilldkg.participant_step2(
+            hostseckeys[0], pstates1[0], invalid_cmsg1, aux_rand
+        ),
         chilldkg.FaultyParticipantOrCoordinatorError,
         1,
     )
@@ -489,7 +503,9 @@ def generate_participant_step2_group(t, n):
     )
     invalid_cmsg1 = invalid_cmsg1_parsed.to_bytes()
     error = expect_exception(
-        lambda: participant_step2(hostseckeys[0], pstates1[0], invalid_cmsg1, aux_rand),
+        lambda: chilldkg.participant_step2(
+            hostseckeys[0], pstates1[0], invalid_cmsg1, aux_rand
+        ),
         chilldkg.UnknownFaultyParticipantOrCoordinatorError,
     )
     error_cases.append(
@@ -502,7 +518,9 @@ def generate_participant_step2_group(t, n):
     # --- Error test case: missing encrypted secret shares ---
     invalid_cmsg1 = cmsg1[:-1]
     error = expect_exception(
-        lambda: participant_step2(hostseckeys[0], pstates1[0], invalid_cmsg1, aux_rand),
+        lambda: chilldkg.participant_step2(
+            hostseckeys[0], pstates1[0], invalid_cmsg1, aux_rand
+        ),
         ValueError,
     )
     error_cases.append(
@@ -519,7 +537,9 @@ def generate_participant_step2_group(t, n):
     )
     invalid_cmsg1 = invalid_cmsg1_parsed.to_bytes()
     error = expect_exception(
-        lambda: participant_step2(hostseckeys[0], pstates1[0], invalid_cmsg1, aux_rand),
+        lambda: chilldkg.participant_step2(
+            hostseckeys[0], pstates1[0], invalid_cmsg1, aux_rand
+        ),
         chilldkg.FaultyCoordinatorError,
     )
     error_cases.append(
@@ -534,7 +554,9 @@ def generate_participant_step2_group(t, n):
     invalid_cmsg1_parsed.enc_cmsg.simpl_cmsg.coms_to_secrets[1] = GE()  # infinity
     invalid_cmsg1 = invalid_cmsg1_parsed.to_bytes()
     error = expect_faulty_exception(
-        lambda: participant_step2(hostseckeys[0], pstates1[0], invalid_cmsg1, aux_rand),
+        lambda: chilldkg.participant_step2(
+            hostseckeys[0], pstates1[0], invalid_cmsg1, aux_rand
+        ),
         chilldkg.FaultyParticipantOrCoordinatorError,
         1,
     )
@@ -552,7 +574,9 @@ def generate_participant_step2_group(t, n):
     )  # random 64 bytes (not a valid signature for any key)
     invalid_cmsg1 = invalid_cmsg1_parsed.to_bytes()
     error = expect_faulty_exception(
-        lambda: participant_step2(hostseckeys[0], pstates1[0], invalid_cmsg1, aux_rand),
+        lambda: chilldkg.participant_step2(
+            hostseckeys[0], pstates1[0], invalid_cmsg1, aux_rand
+        ),
         chilldkg.FaultyParticipantOrCoordinatorError,
         1,
     )
@@ -571,7 +595,7 @@ def generate_participant_step2_group(t, n):
         )
         invalid_cmsg1 = invalid_cmsg1_parsed.to_bytes()
         error = expect_exception(
-            lambda: participant_step2(
+            lambda: chilldkg.participant_step2(
                 hostseckeys[0], pstates1[0], invalid_cmsg1, aux_rand
             ),
             chilldkg.UnknownFaultyParticipantOrCoordinatorError,
@@ -590,7 +614,7 @@ def generate_participant_step2_group(t, n):
         )
         invalid_cmsg1 = invalid_cmsg1_parsed.to_bytes()
         error = expect_exception(
-            lambda: participant_step2(
+            lambda: chilldkg.participant_step2(
                 hostseckeys[0], pstates1[0], invalid_cmsg1, aux_rand
             ),
             chilldkg.UnknownFaultyParticipantOrCoordinatorError,
@@ -611,7 +635,9 @@ def generate_participant_step2_group(t, n):
     invalid_pmsgs1[1] = pmsgs11_parsed.to_bytes()
     _, invalid_cmsg1 = chilldkg.coordinator_step1(invalid_pmsgs1, params)
     error = expect_exception(
-        lambda: participant_step2(hostseckeys[0], pstates1[0], invalid_cmsg1, aux_rand),
+        lambda: chilldkg.participant_step2(
+            hostseckeys[0], pstates1[0], invalid_cmsg1, aux_rand
+        ),
         chilldkg.UnknownFaultyParticipantOrCoordinatorError,
     )
     error_cases.append(
@@ -674,7 +700,7 @@ def generate_participant_finalize_group(t, n):
     pstates1 = []
     pmsgs1 = []
     for i in range(len(hostpubkeys)):
-        state, msg = participant_step1(hostseckeys[i], params, randoms[i])
+        state, msg = chilldkg.participant_step1(hostseckeys[i], params, randoms[i])
         pstates1.append(state)
         pmsgs1.append(msg)
     cstate, cmsg1 = chilldkg.coordinator_step1(pmsgs1, params)
@@ -682,7 +708,9 @@ def generate_participant_finalize_group(t, n):
     pstates2 = []
     pmsgs2 = []
     for i in range(len(hostpubkeys)):
-        state, msg = participant_step2(hostseckeys[i], pstates1[i], cmsg1, aux_rand)
+        state, msg = chilldkg.participant_step2(
+            hostseckeys[i], pstates1[i], cmsg1, aux_rand
+        )
         pstates2.append(state)
         pmsgs2.append(msg)
 
@@ -701,7 +729,7 @@ def generate_participant_finalize_group(t, n):
 
     # --- Valid test case ---
     cmsg2, _, _ = chilldkg.coordinator_finalize(cstate, pmsgs2)
-    pout, prec = participant_finalize(pstates2[0], cmsg2)
+    pout, prec = chilldkg.participant_finalize(pstates2[0], cmsg2)
 
     valid_cases.append(
         {
@@ -719,7 +747,7 @@ def generate_participant_finalize_group(t, n):
         cmsg2[:-64]
     ).to_bytes()  # remove last signature
     error = expect_exception(
-        lambda: participant_finalize(pstates2[0], invalid_cmsg2),
+        lambda: chilldkg.participant_finalize(pstates2[0], invalid_cmsg2),
         ValueError,
     )
     error_cases.append(
@@ -732,7 +760,7 @@ def generate_participant_finalize_group(t, n):
     # --- Error test case: cmsg2 is too long ---
     invalid_cmsg2 = chilldkg.CoordinatorMsg2(cmsg2 + bytes(64)).to_bytes()
     error = expect_exception(
-        lambda: participant_finalize(pstates2[0], invalid_cmsg2),
+        lambda: chilldkg.participant_finalize(pstates2[0], invalid_cmsg2),
         ValueError,
     )
     error_cases.append(
@@ -750,7 +778,7 @@ def generate_participant_finalize_group(t, n):
     assert len(random_sig) == 64
     invalid_cmsg2_2 = chilldkg.CoordinatorMsg2(cmsg2[:-64] + random_sig).to_bytes()
     error2 = expect_exception(
-        lambda: participant_finalize(pstates2[0], invalid_cmsg2_2),
+        lambda: chilldkg.participant_finalize(pstates2[0], invalid_cmsg2_2),
         chilldkg.FaultyCoordinatorError,
     )
     error_cases.append(
@@ -812,7 +840,7 @@ def generate_participant_investigate_group(t, n):
     pstates1 = []
     pmsgs1 = []
     for i in range(len(hostpubkeys)):
-        state, msg = participant_step1(hostseckeys[i], params, randoms[i])
+        state, msg = chilldkg.participant_step1(hostseckeys[i], params, randoms[i])
         pstates1.append(state)
         pmsgs1.append(msg)
     _, cmsg1 = chilldkg.coordinator_step1(pmsgs1, params)
@@ -829,11 +857,11 @@ def generate_participant_investigate_group(t, n):
     invalid_pmsgs1[1] = invalid_pmsg1_parsed.to_bytes()
     _, invalid_cmsg1 = chilldkg.coordinator_step1(invalid_pmsgs1, params)
     try:
-        participant_step2(hostseckeys[0], pstates1[0], invalid_cmsg1, aux_rand)
+        chilldkg.participant_step2(hostseckeys[0], pstates1[0], invalid_cmsg1, aux_rand)
     except chilldkg.UnknownFaultyParticipantOrCoordinatorError as e:
         cinv_msgs = chilldkg.coordinator_investigate(invalid_pmsgs1, params)
         error = expect_faulty_exception(
-            lambda e=e: participant_investigate(e, cinv_msgs[0]),
+            lambda e=e: chilldkg.participant_investigate(e, cinv_msgs[0]),
             chilldkg.FaultyParticipantOrCoordinatorError,
             1,
         )
@@ -859,11 +887,11 @@ def generate_participant_investigate_group(t, n):
     invalid_cmsg1 = invalid_cmsg1_parsed.to_bytes()
 
     try:
-        participant_step2(hostseckeys[0], pstates1[0], invalid_cmsg1, aux_rand)
+        chilldkg.participant_step2(hostseckeys[0], pstates1[0], invalid_cmsg1, aux_rand)
     except chilldkg.UnknownFaultyParticipantOrCoordinatorError as e:
         cinv_msgs = chilldkg.coordinator_investigate(pmsgs1, params)
         error = expect_exception(
-            lambda e=e: participant_investigate(e, cinv_msgs[0]),
+            lambda e=e: chilldkg.participant_investigate(e, cinv_msgs[0]),
             chilldkg.FaultyCoordinatorError,
         )
     else:
@@ -882,7 +910,7 @@ def generate_participant_investigate_group(t, n):
     # --- Error test case: Coordinator tampered with self-encrypted partial secshare ---
     try:
         # using the prior invalid_cmsg1 to trigger the error
-        participant_step2(hostseckeys[0], pstates1[0], invalid_cmsg1, aux_rand)
+        chilldkg.participant_step2(hostseckeys[0], pstates1[0], invalid_cmsg1, aux_rand)
     except chilldkg.UnknownFaultyParticipantOrCoordinatorError as e:
         cinv_msgs = chilldkg.coordinator_investigate(pmsgs1, params)
         cinv_msg_parsed = chilldkg.CoordinatorInvestigationMsg.from_bytes(
@@ -894,7 +922,7 @@ def generate_participant_investigate_group(t, n):
         )  # invalid share
         invalid_cinv_msg0 = invalid_cinv_msg0_parsed.to_bytes()
         error = expect_exception(
-            lambda e=e: participant_investigate(e, invalid_cinv_msg0),
+            lambda e=e: chilldkg.participant_investigate(e, invalid_cinv_msg0),
             chilldkg.FaultyCoordinatorError,
         )
     else:
@@ -912,7 +940,7 @@ def generate_participant_investigate_group(t, n):
     # --- Error test case: partial pubshares list in cinv_msg has an arbitrary value at index 1 ---
     try:
         # using the prior invalid_cmsg1 to trigger the error
-        participant_step2(hostseckeys[0], pstates1[0], invalid_cmsg1, aux_rand)
+        chilldkg.participant_step2(hostseckeys[0], pstates1[0], invalid_cmsg1, aux_rand)
     except chilldkg.UnknownFaultyParticipantOrCoordinatorError as e:
         cinv_msgs = chilldkg.coordinator_investigate(pmsgs1, params)
         cinv_msg_parsed = chilldkg.CoordinatorInvestigationMsg.from_bytes(
@@ -924,7 +952,7 @@ def generate_participant_investigate_group(t, n):
         )
         invalid_cinv_msg0 = invalid_cinv_msg0_parsed.to_bytes()
         error = expect_exception(
-            lambda e=e: participant_investigate(e, invalid_cinv_msg0),
+            lambda e=e: chilldkg.participant_investigate(e, invalid_cinv_msg0),
             chilldkg.FaultyCoordinatorError,
         )
     else:

--- a/python/gen_vector_utils/session.py
+++ b/python/gen_vector_utils/session.py
@@ -2,7 +2,6 @@ from secp256k1lab.secp256k1 import Scalar
 from secp256k1lab.util import bytes_from_int
 
 from chilldkg_ref import chilldkg
-from chilldkg_ref.chilldkg import hostpubkey_gen, params_hash
 
 from .fixtures import AUX_RAND_HEX, HOSTSECKEYS_HEX, RANDOMS_HEX
 from .util import (
@@ -34,7 +33,7 @@ def generate_hostpubkey_vectors():
     hostseckey = bytes.fromhex(
         "631C047D50A67E45E27ED1FF25FCE179CAF059A2120D346ACD9774C1F2BAB66F"
     )
-    expected_pubkey = hostpubkey_gen(hostseckey)
+    expected_pubkey = chilldkg.hostpubkey_gen(hostseckey)
     valid_cases.append(
         {
             "hostseckey": bytes_to_hex(hostseckey),
@@ -46,7 +45,9 @@ def generate_hostpubkey_vectors():
     # --- Error test case: Wrong length ---
     short_hostseckey = bytes.fromhex("631C047D50A67E45E27ED1FF25FCE179")
     assert len(short_hostseckey) == 16
-    error = expect_exception(lambda: hostpubkey_gen(short_hostseckey), ValueError)
+    error = expect_exception(
+        lambda: chilldkg.hostpubkey_gen(short_hostseckey), ValueError
+    )
     error_cases.append(
         {
             "hostseckey": bytes_to_hex(short_hostseckey),
@@ -57,7 +58,7 @@ def generate_hostpubkey_vectors():
     # --- Error test case: Out-of-range hostseckey ---
     invalid_hostseckey = bytes_from_int(Scalar.SIZE)
     error = expect_exception(
-        lambda: hostpubkey_gen(invalid_hostseckey), chilldkg.HostSeckeyError
+        lambda: chilldkg.hostpubkey_gen(invalid_hostseckey), chilldkg.HostSeckeyError
     )
     error_cases.append(
         {
@@ -69,7 +70,7 @@ def generate_hostpubkey_vectors():
     # --- Error test case: zeroed hostseckey ---
     zeroed_hostseckey = b"\x00" * 32
     error = expect_exception(
-        lambda: hostpubkey_gen(zeroed_hostseckey), chilldkg.HostSeckeyError
+        lambda: chilldkg.hostpubkey_gen(zeroed_hostseckey), chilldkg.HostSeckeyError
     )
     error_cases.append(
         {
@@ -106,7 +107,7 @@ def generate_params_hash_vectors():
     valid_cases = []
     error_cases = []
     hostseckeys = hex_list_to_bytes(HOSTSECKEYS_HEX[:3])
-    hostpubkeys = [hostpubkey_gen(sk) for sk in hostseckeys]
+    hostpubkeys = [chilldkg.hostpubkey_gen(sk) for sk in hostseckeys]
 
     # --- Valid test cases ---
     cases = [
@@ -118,7 +119,7 @@ def generate_params_hash_vectors():
     for case in cases:
         t = case["t"]
         params = chilldkg.SessionParams(hostpubkeys, t)
-        expected_params_hash = params_hash(params)
+        expected_params_hash = chilldkg.params_hash(params)
         test_case = {
             "params": params_asdict(params),
             "expectedParamsHash": bytes_to_hex(expected_params_hash),
@@ -130,7 +131,7 @@ def generate_params_hash_vectors():
     t = 0
     invalid_params = chilldkg.SessionParams(hostpubkeys, t)
     error = expect_exception(
-        lambda: params_hash(invalid_params), chilldkg.ThresholdOrCountError
+        lambda: chilldkg.params_hash(invalid_params), chilldkg.ThresholdOrCountError
     )
     error_cases.append(
         {
@@ -145,7 +146,7 @@ def generate_params_hash_vectors():
     with_invalid = [hostpubkeys[0], invalid_hostpubkey, hostpubkeys[2]]
     invalid_params = chilldkg.SessionParams(with_invalid, t)
     error = expect_exception(
-        lambda: params_hash(invalid_params), chilldkg.InvalidHostPubkeyError
+        lambda: chilldkg.params_hash(invalid_params), chilldkg.InvalidHostPubkeyError
     )
     error_cases.append(
         {
@@ -159,7 +160,8 @@ def generate_params_hash_vectors():
     with_duplicate = [hostpubkeys[0], hostpubkeys[1], hostpubkeys[2], hostpubkeys[1]]
     duplicate_params = chilldkg.SessionParams(with_duplicate, t)
     error = expect_exception(
-        lambda: params_hash(duplicate_params), chilldkg.DuplicateHostPubkeyError
+        lambda: chilldkg.params_hash(duplicate_params),
+        chilldkg.DuplicateHostPubkeyError,
     )
     error_cases.append(
         {

--- a/python/gen_vector_utils/util.py
+++ b/python/gen_vector_utils/util.py
@@ -4,11 +4,7 @@ import json
 from pathlib import Path
 from typing import TypeAlias
 
-from chilldkg_ref import encpedpop
-from chilldkg_ref.chilldkg import (
-    DKGOutput,
-    SessionParams,
-)
+from chilldkg_ref import chilldkg, encpedpop
 
 ErrorInfo: TypeAlias = "dict[str, int | str | ErrorInfo]"
 
@@ -71,11 +67,11 @@ def expect_faulty_exception(try_fn, expected_exception, expected_participant):
     return error
 
 
-def params_asdict(params: SessionParams) -> dict:
+def params_asdict(params: chilldkg.SessionParams) -> dict:
     return {"hostpubkeys": bytes_list_to_hex(params.hostpubkeys), "t": params.t}
 
 
-def dkg_output_asdict(dkg_output: DKGOutput) -> dict:
+def dkg_output_asdict(dkg_output: chilldkg.DKGOutput) -> dict:
     secshare = bytes_to_hex(dkg_output.secshare) if dkg_output.secshare else None
     return {
         "secshare": secshare,
@@ -108,8 +104,8 @@ def assert_raises(try_fn, expected_error: dict):
         raise AssertionError("Expected exception")
 
 
-def params_from_dict(params: dict) -> SessionParams:
-    return SessionParams(
+def params_from_dict(params: dict) -> chilldkg.SessionParams:
+    return chilldkg.SessionParams(
         hex_list_to_bytes(params["hostpubkeys"]),
         params["t"],
     )


### PR DESCRIPTION
Just code hygiene. Previously, we were a bit inconsistent about how we import from chilldkg_ref.