### PR TITLE
Clarify Licensing

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) The ChillDKG authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ This Bitcoin Improvement Proposal proposes ChillDKG, a distributed key generatio
 ### Copyright
 
 This document is made available under [CC0 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/).
-The accompanying source code is licensed under the [MIT license](https://opensource.org/license/mit).
+The accompanying auxiliary files are licensed under the [MIT License](https://opensource.org/license/mit).
+The collection of test vectors therein (subdirectory `vectors/`) is, in addition to the MIT License, available under CC0 1.0 Universal.
 
 ## Introduction
 

--- a/vectors/COPYING
+++ b/vectors/COPYING
@@ -1,0 +1,9 @@
+MIT OR CC0-1.0
+
+The files in this directory are provided under one of the following sets of
+terms, at your choice:
+
+ - The MIT License
+   https://opensource.org/license/MIT (see also ../COPYING)
+ - CC0 1.0 Universal
+   https://creativecommons.org/publicdomain/zero/1.0/


### PR DESCRIPTION
BIP recommends having the test vectors under CC0 